### PR TITLE
Add link to nixpkgs repository

### DIFF
--- a/nixpkgs/index.tt
+++ b/nixpkgs/index.tt
@@ -1,8 +1,8 @@
 [% WRAPPER layout.tt title="The Nix Packages collection" menu='nixpkgs' %]
 
-<p>The <em>Nix Packages collection</em> (Nixpkgs) is a set of nearly
-6,500 packages for the Nix package manager, released under a <a
-href="https://github.com/NixOS/nixpkgs/blob/master/COPYING">permissive
+<p>The <em>Nix Packages collection</em> (<a href="https://github.com/NixOS/nixpkgs">
+Nixpkgs</a>) is a set of nearly 6,500 packages for the Nix package manager, released
+under a <a href="https://github.com/NixOS/nixpkgs/blob/master/COPYING">permissive
 MIT/X11 license</a>.  It supports a number of platforms (though not
 all packages work on all platforms):</p>
 


### PR DESCRIPTION
This adds a link to the nixpkgs repository to the index page of the nixpkgs homepage as I have not found any reference to the repository on these sites.
