### PR TITLE
Make options search work in non-ES6 browsers.

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -230,7 +230,7 @@ function ppNix(indent, v) {
   if (typeof v == "string") {
     v = v.replace('<', '&lt;').replace('>', '&gt;');
     if (v.indexOf('"') == -1 && v.indexOf('\n') == -1) {
-      if (v.startsWith("pkgs."))
+      if (/^pkgs\./.test(v))
         return '' + v;
       return '"' + v + '"';
     }


### PR DESCRIPTION
Use regex instead of ES6 String.prototype.startsWith method which isn't
available in all browsers.