### PR TITLE
Mention newer nixpkgs releases in download.html

### DIFF
--- a/nixpkgs/download.tt
+++ b/nixpkgs/download.tt
@@ -44,6 +44,10 @@ continuous build system:</p>
 
 <section><h2>Old releases</h2>
 
+<p><strong>Note:</strong>This section is out of date.  NixOS/nixpkgs releases now follow a year.month naming style.
+See the release notes section of the <a href="https://nixos.org/nixos/manual/index.html">NixOS manual table of contents</a>
+for a list of more recent releases.</p>
+
 <p>The following old releases of Nixpkgs are available:</p>
 
 <div class="row">


### PR DESCRIPTION
Is there a better place to link to here? The only list of releases I found was in the table of contents of the NixOS manual, under "Release Notes", because there just happens to be a release notes section for every release.

(Related question: do we have any other information about the release process documented? E.g. how long do they receive support?)