### PR TITLE
Restore the project menu

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -26,8 +26,20 @@ p {
     hyphens: auto;
 }
 
+.brand > a {
+    color: #777;
+    text-decoration: none;
+}
+
+.brand > a:hover {
+    color: #333;
+    text-decoration: none;
+}
+
 .logo {
     margin-top: -5px;
+    padding-right: 5px;
+    line-height: 25px;
     height: 25px;
 }
 

--- a/layout.tt
+++ b/layout.tt
@@ -38,20 +38,33 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="brand" href="[%root%]">
-            <img src="[% root %]logo/nix-wiki.png" alt="NixOS" class="logo" />
-          </a>
-          [% IF menu == 'nix' %]
-            <a class="brand" href="[%root%]nix">Nix</a>
-          [% ELSIF menu == 'nixpkgs' %]
-            <a class="brand" href="[%root%]nixpkgs">Nixpkgs</a>
-          [% ELSIF menu == 'nixops' %]
-            <a class="brand" href="[%root%]nixops">NixOps</a>
-          [% ELSIF menu == 'disnix' %]
-            <a class="brand" href="[%root%]disnix">Disnix</a>
-          [% ELSE %]
-            <a class="brand" href="[% (root == '' ? '/' : root) %]">NixOS</a>
-          [% END %]
+          <li class="dropdown brand">
+            <a class="dropdown-toggle" href="#" data-toggle="dropdown">
+              <img src="[% root %]logo/nix-wiki.png" alt="NixOS" class="logo" />
+              [% IF menu == 'nix' %]
+                Nix
+              [% ELSIF menu == 'nixpkgs' %]
+                Nixpkgs
+              [% ELSIF menu == 'nixops' %]
+                NixOps
+              [% ELSIF menu == 'disnix' %]
+                Disnix
+              [% ELSE %]
+                NixOS
+              [% END %]
+              <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a href="[%root%]">NixOS</a></li>
+              <li><a href="[%root%]nix">Nix</a></li>
+              <li><a href="[%root%]nixops">NixOps</a></li>
+              <li><a href="[%root%]nixpkgs">Nixpkgs</a></li>
+              <li class="divider"></li>
+              <li><a href="[%root%]hydra">Hydra</a></li>
+              <li><a href="[%root%]disnix">Disnix</a></li>
+            </ul>
+          </li>
+
           <div class="nav-collapse collapse">
             [% IF menu == 'nixos' %]
               <ul class="nav pull-left">
@@ -106,20 +119,7 @@
             [% ELSE %]
               <ul class="nav pull-right">
             [% END %]
-              <!--
-              <li class="dropdown">
-                <a class="dropdown-toggle" href="#" data-toggle="dropdown">Projects<b class="caret"></b></a>
-                <ul class="dropdown-menu">
-                  <li><a href="[%root%]">NixOS</a></li>
-                  <li><a href="[%root%]nix">Nix</a></li>
-                  <li><a href="[%root%]nixops">NixOps</a></li>
-                  <li><a href="[%root%]nixpkgs">Nixpkgs</a></li>
-                  <li class="divider"></li>
-                  <li><a href="[%root%]hydra">Hydra</a></li>
-                  <li><a href="[%root%]disnix">Disnix</a></li>
-                </ul>
-              </li>
-              -->
+
               <form class="navbar-search" method="get" action="https://www.google.com/search">
                 <input name="q" type="text" class="search-query span2" placeholder="Search nixos.org"/>
                 <input name="sitesearch" type="hidden" value="nixos.org"/>


### PR DESCRIPTION
This helps with the naviation and discoverability of the various projects.
Right now the user has to either follow the links or enter the right path in
the URL to navigate between these.

This tries to fix one of the complaint @garbas had during the talk.

<img width="410" alt="screen shot 2015-11-15 at 00 32 14" src="https://cloud.githubusercontent.com/assets/3248/11166361/5af49820-8b30-11e5-84c8-d8c5f1ab4862.png">
