### PR TITLE
Remove justified alignment from p tags

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -20,7 +20,6 @@ body {
 
 
 p {
-    text-align: justify;
     -webkit-hyphens: auto;
     -moz-hyphens: auto;
     hyphens: auto;


### PR DESCRIPTION
Remove `text-align: justify` from paragraphs as it adds little and can harm readability significantly.

I'd argue it should never be used, but I only noticed it in the paragraph tag.

Before:
<img width="936" alt="screen shot 2015-12-27 at 1 26 29 am" src="https://cloud.githubusercontent.com/assets/25628/12009123/4261dad2-ac39-11e5-89c1-a4cbeda57b0c.png">

After:

<img width="950" alt="screen shot 2015-12-27 at 1 26 46 am" src="https://cloud.githubusercontent.com/assets/25628/12009124/47df500c-ac39-11e5-9065-d663b03c4c09.png">
