### PR TITLE
install.in: mktemp -d and reliably cleanup tarball dir on exit

### DIFF
--- a/nix/install.in
+++ b/nix/install.in
@@ -5,19 +5,22 @@
 # (which in turn creates and populates /nix).
 
 { # Prevent execution if this script was only partially downloaded
-
-unpack=nix-binary-tarball-unpack
+oops() {
+    echo "$0: $@" >&2
+    exit 1
+}
+unpack="$(mktemp -d nix-binary-tarball-unpack.XXXXXXXXXX || \
+          oops "Can't create tempdir for unpacking")"
+cleanup() {
+    rm -rf "$unpack"
+}
+trap cleanup EXIT INT QUIT TERM
 
 require_util() {
     type "$1" > /dev/null 2>&1 || which "$1" > /dev/null 2>&1 ||
         oops "you do not have \`$1' installed, which i need to $2"
 }
 
-oops() {
-    echo "$0: $@" >&2
-    rm -rf "$unpack"
-    exit 1
-}
 
 case "$(uname -s).$(uname -m)" in
     Linux.x86_64) system=x86_64-linux;;
@@ -31,16 +34,13 @@ url="https://nixos.org/releases/nix/nix-[%latestNixVersion%]/nix-[%latestNixVers
 require_util curl "download the binary tarball"
 require_util bzcat "decompress the binary tarball"
 require_util tar "unpack the binary tarball"
-require_util bash "run the installation script from the binary tarball"
 
 echo "unpacking Nix binary tarball for $system from \`$url'..."
-mkdir "$unpack" || oops "failed to create \`$unpack' directory"
 curl -L "$url" | bzcat | tar x -C "$unpack" || oops "failed to unpack \`$url'"
 
 [ -e "$unpack"/*/install ] ||
     oops "installation script is missing from the binary tarball!"
 
 "$unpack"/*/install
-rm -rf "$unpack"
 
 } # End of wrapping


### PR DESCRIPTION
[Copied from #62, since the underlying repo for the PR went away]
This PR should make the default installation method a little bit more robust:

curl https://nixos.org/nix/install | sh
As it is, after a failed attempt to run the above (e.g. due to a keyboard interrupt or failed partial download) the second invocation of the same command will also fail because the nix-binary-tarball-unpack directory won't have been cleaned up and the attempt to mkdir it at the same location will error out.

This PR uses mktemp (in a way that should work at least on OS X and Linux) and an exit trap to fix this.