### PR TITLE
Nix install script: Fix Bash-ism, quoting issues

### DIFF
--- a/nix/install.in
+++ b/nix/install.in
@@ -6,7 +6,7 @@
 
 { # Prevent execution if this script was only partially downloaded
 oops() {
-    echo "$0: $@" >&2
+    echo "$0:" "$@" >&2
     exit 1
 }
 
@@ -31,7 +31,7 @@ esac
 
 url="https://nixos.org/releases/nix/nix-[%latestNixVersion%]/nix-[%latestNixVersion%]-$system.tar.bz2"
 
-tarball="$tmpDir/$(basename $tmpDir/nix-[%latestNixVersion%]-$system.tar.bz2)"
+tarball="$tmpDir/$(basename "$tmpDir/nix-[%latestNixVersion%]-$system.tar.bz2")"
 
 require_util curl "download the binary tarball"
 require_util bzcat "decompress the binary tarball"
@@ -43,7 +43,7 @@ curl -L "$url" -o "$tarball" || oops "failed to download '$url'"
 
 hash2="$(shasum -a 512 -b "$tarball" | cut -c1-128)"
 
-if [[ $hash != $hash2 ]]; then
+if [ "$hash" != "$hash2" ]; then
     oops "SHA-512 hash mismatch in '$url'; expected $hash, got $hash2"
 fi
 


### PR DESCRIPTION
In the Nix installation script at `nix/install.in`, replace a Bash-ism
with its POSIX-compatible equivalent, and fix some (minor) quoting
issues found by ShellCheck.

Credit to @wycats for hitting the Bash-ism, and thereby prompting me to
fix it.

NOTE: This will require the PGP signature at `nix/install.sig` to be
updated, which I don't believe I can do.