### PR TITLE
Correct URLs for wget on installer

### DIFF
--- a/nix/download.tt
+++ b/nix/download.tt
@@ -12,7 +12,8 @@ other than <tt>root</tt>):
 You may want to verify the integrity of the installation script using GPG:
 
 <pre>
-<span class="muted">$</span> wget <a href="[%root%]nix/install">http://localhost/nix/install</a> wget <a href="[%root%]nix/install.sig">http://localhost/nix/install.sig</a>
+<span class="muted">$</span> wget <a href="[%root%]nix/install">[%root%]nix/install</a>
+<span class="muted">$</span> wget <a href="[%root%]nix/install.sig">[%root%]nix/install.sig</a>
 <span class="muted">$</span> gpg2 --verify ./install.sig
 <span class="muted">$</span> sh ./install
 </pre>


### PR DESCRIPTION
the current install directions are incorrect:

    $ wget http://localhost/nix/install wget http://localhost/nix/install.sig