### PR TITLE
Don't require shasum for the Nix installer

### DIFF
--- a/nix/install.in
+++ b/nix/install.in
@@ -36,7 +36,6 @@ tarball="$tmpDir/$(basename "$tmpDir/nix-[%latestNixVersion%]-$system.tar.bz2")"
 require_util curl "download the binary tarball"
 require_util bzcat "decompress the binary tarball"
 require_util tar "unpack the binary tarball"
-require_util shasum "verify the binary tarball"
 
 echo "downloading Nix binary tarball for $system from '$url' to '$tmpDir'..."
 curl -L "$url" -o "$tarball" || oops "failed to download '$url'"


### PR DESCRIPTION
Recently, the installer script was updated to use sha512sum or openssl
if available, falling back only to shasum if necessary. Since shasum is
no longer needed and there is separate code that checks for each
utility, we no longer need to `require_util` shasum.

Refs #86.