### PR TITLE
(partial) fix for #89

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -257,7 +257,7 @@ function showOption() {
 
   var details = $('#details-template').clone().removeAttr('id').show();
 
-  var x = $.parseXML("<div>" + opt.description + "</div>");
+  var x = $.parseXML('<xml xmlns:xlink="http://www.w3.org/1999/xlink"><div>' + opt.description + '</div></xml>');
   $('.description', details).empty().append($(x).text());
 
   if ('default' in opt)


### PR DESCRIPTION
(partial) fix for issue #89
- option description is now fully displayed and now longer truncated
- links are still not rendered as HTML links
