### PR TITLE
Point out install script outputs instructions

### DIFF
--- a/nix/download.tt
+++ b/nix/download.tt
@@ -9,6 +9,8 @@ other than <tt>root</tt>):
 
 <pre><span class="muted">$</span> curl <a href="[%root%]nix/install">https://nixos.org/nix/install</a> | sh</pre>
 
+Make sure to follow the instructions output by the script.
+
 You may want to verify the integrity of the installation script using GPG:
 
 <pre>


### PR DESCRIPTION
Point to distracted readers that the script outputs further instructions.

Alternatively, we could duplicate those instructions here if they're stable enough. That seems plausible, but I'm too new to Nix to be sure. OTOH, I'm not sure the current uninstall instructions are accurate (see #99).