### PR TITLE
Use curl for both download examples

### DIFF
--- a/nix/download.tt
+++ b/nix/download.tt
@@ -14,8 +14,8 @@ Make sure to follow the instructions output by the script.
 You may want to verify the integrity of the installation script using GPG:
 
 <pre>
-<span class="muted">$</span> wget <a href="[%root%]nix/install">https://nixos.org/nix/install</a>
-<span class="muted">$</span> wget <a href="[%root%]nix/install.sig">https://nixos.org/nix/install.sig</a>
+<span class="muted">$</span> curl -O <a href="[%root%]nix/install">https://nixos.org/nix/install</a>
+<span class="muted">$</span> curl -O <a href="[%root%]nix/install.sig">https://nixos.org/nix/install.sig</a>
 <span class="muted">$</span> gpg2 --verify ./install.sig
 <span class="muted">$</span> sh ./install
 </pre>


### PR DESCRIPTION
Rather than switching between curl and wget, stick with the same command.