### PR TITLE
Fix numbering of NixOS releases on news page

### DIFF
--- a/news.xml
+++ b/news.xml
@@ -7,7 +7,7 @@
       NixOS 16.09 released
     </title>
     <description>
-      NixOS 16.09 “Flounder” has been released, the fifth stable release
+      NixOS 16.09 “Flounder” has been released, the sixth stable release
       branch. See the <a
       href="/nixos/manual/release-notes.html#sec-release-16.09">release notes</a>
       for details. You can get NixOS 16.09 ISOs and VirtualBox
@@ -39,7 +39,7 @@
       NixOS 16.03 released
     </title>
     <description>
-      NixOS 16.03 “Emu” has been released, the fourth stable release
+      NixOS 16.03 “Emu” has been released, the fifth stable release
       branch. See the <a
       href="/nixos/manual/release-notes.html#sec-release-16.03">release notes</a>
       for details. You can get NixOS 16.03 ISOs and VirtualBox


### PR DESCRIPTION
There are currently two "fourth stable release branch" of NixOS.
Unless I didn't get something, this commit should fix the numbering on the announcement page.