### PR TITLE
Update logo with version that doesn't require specific font installed

### DIFF
--- a/logo/nixos-hex.svg
+++ b/logo/nixos-hex.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 1543.4284 484.31659"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="logo-hex.svg">
+   inkscape:version="0.92.0 r15299"
+   sodipodi:docname="nixos-hex.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -68,22 +68,6 @@
          style="stop-color:#719efa;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5867">
-      <stop
-         style="stop-color:#7363df;stop-opacity:1"
-         offset="0"
-         id="stop5869" />
-      <stop
-         id="stop5871"
-         offset="0.23168644"
-         style="stop-color:#6478fa;stop-opacity:1" />
-      <stop
-         style="stop-color:#719efa;stop-opacity:1"
-         offset="1"
-         id="stop5873" />
-    </linearGradient>
-    <linearGradient
        y2="515.97058"
        x2="282.26105"
        y1="338.62445"
@@ -92,116 +76,6 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient5855"
        xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="515.97058"
-       x2="282.26105"
-       y1="338.62445"
-       x1="213.95642"
-       gradientTransform="translate(-197.75174,-337.1451)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5855-8"
-       xlink:href="#linearGradient5867"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="247.58188"
-       x2="-702.75317"
-       y1="102.74675"
-       x1="-775.20807"
-       gradientTransform="translate(983.36076,601.38885)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4544"
-       xlink:href="#linearGradient5960"
-       inkscape:collect="always" />
-    <clipPath
-       id="clipPath4501"
-       clipPathUnits="userSpaceOnUse">
-      <circle
-         r="241.06563"
-         cy="686.09473"
-         cx="335.13995"
-         id="circle4503"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#adadad;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    </clipPath>
-    <clipPath
-       id="clipPath5410"
-       clipPathUnits="userSpaceOnUse">
-      <circle
-         r="241.13741"
-         cy="340.98975"
-         cx="335.98114"
-         id="circle5412"
-         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5053"
-       id="linearGradient5137"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(864.55062,-2197.497)"
-       x1="-584.19934"
-       y1="782.33563"
-       x2="-496.29703"
-       y2="937.71399" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5053"
-       id="linearGradient5147"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(864.55062,-2197.497)"
-       x1="-584.19934"
-       y1="782.33563"
-       x2="-496.29703"
-       y2="937.71399" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5562"
-       id="linearGradient5162"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(70.505061,-1761.3076)"
-       x1="200.59668"
-       y1="351.41116"
-       x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5562"
-       id="linearGradient5172"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(70.505061,-1761.3076)"
-       x1="200.59668"
-       y1="351.41116"
-       x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5562"
-       id="linearGradient5182"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(70.505061,-1761.3076)"
-       x1="200.59668"
-       y1="351.41116"
-       x2="290.08701"
-       y2="506.18814" />
-    <linearGradient
-       y2="506.18814"
-       x2="290.08701"
-       y1="351.41116"
-       x1="200.59668"
-       gradientTransform="translate(70.505061,-1761.3076)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5201"
-       xlink:href="#linearGradient5562"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="937.71399"
-       x2="-496.29703"
-       y1="782.33563"
-       x1="-584.19934"
-       gradientTransform="translate(864.55062,-2197.497)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient5205"
-       xlink:href="#linearGradient5053"
        inkscape:collect="always" />
     <linearGradient
        inkscape:collect="always"
@@ -231,16 +105,16 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.69521484"
+     inkscape:zoom="0.34760742"
      inkscape:cx="803.54996"
-     inkscape:cy="-74.768069"
+     inkscape:cy="186.45699"
      inkscape:document-units="px"
-     inkscape:current-layer="layer6"
+     inkscape:current-layer="g5329"
      showgrid="false"
-     inkscape:window-width="1920"
-     inkscape:window-height="1128"
+     inkscape:window-width="1366"
+     inkscape:window-height="706"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:snap-global="true"
      fit-margin-top="0"
@@ -255,7 +129,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -293,7 +167,6 @@
        height="435.68069"
        x="155.77646"
        y="-933.38721"
-       inkscape:export-filename="/home/tim/dev/nix/homepage/logo/nixos-lores-no-alpha.png"
        inkscape:export-xdpi="17.971878"
        inkscape:export-ydpi="17.971878" />
     <rect
@@ -453,7 +326,7 @@
          inkscape:flatsided="true"
          inkscape:rounded="0"
          inkscape:randomized="0"
-         d="m 251.98568,878.63831 -14.02447,24.29109 -28.04894,0 -14.02447,-24.29109 14.02447,-24.2911 28.04894,0 z" />
+         d="m 251.98568,878.63831 -14.02447,24.29109 h -28.04894 l -14.02447,-24.29109 14.02447,-24.2911 h 28.04894 z" />
       <use
          x="0"
          y="0"
@@ -546,51 +419,41 @@
      id="g5329"
      inkscape:groupmode="layer"
      transform="translate(-132.5822,958.04022)">
-    <text
-       inkscape:export-ydpi="67.440002"
-       inkscape:export-xdpi="67.440002"
-       inkscape:export-filename="/home/tim/dev/nix/logo/poll/text.png"
-       xml:space="preserve"
+    <g
+       aria-label="Nix"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:395.09683228px;line-height:125%;font-family:Carlito;-inkscape-font-specification:Carlito;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="726.16864"
-       y="-579.24268"
-       id="text5407"
-       sodipodi:linespacing="125%"><tspan
+       id="text5407">
+      <path
+         d="m 969.15319,-847.11833 h -30.81755 v 139.86428 c 0,19.75484 0.79019,50.96749 1.97548,85.73601 h -1.18529 c -15.40877,-28.84207 -32.79303,-56.49884 -45.04104,-75.46349 l -96.79872,-150.1368 h -42.27536 v 267.87565 h 30.81755 v -139.86427 c 0,-19.75485 -0.79019,-56.89395 -1.97548,-91.26737 h 1.18529 c 22.91561,39.90478 36.34891,62.0302 48.99201,80.99485 l 96.79872,150.13679 h 38.32439 z"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
-         sodipodi:role="line"
-         id="tspan5409"
-         x="726.16864"
-         y="-579.24268">Nix</tspan></text>
-    <text
-       sodipodi:linespacing="125%"
-       id="text5356"
-       y="-547.966"
-       x="1314.3683"
+         id="path4683" />
+      <path
+         d="m 1027.8251,-579.24268 h 33.1881 v -191.22686 h -33.1881 z m 16.594,-219.27874 c 11.4578,0 20.5451,-9.08722 20.5451,-20.54503 0,-11.45781 -9.0873,-20.54504 -20.5451,-20.54504 -11.4578,0 -20.545,9.08723 -20.545,20.54504 0,11.45781 9.0872,20.54503 20.545,20.54503 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
+         id="path4685" />
+      <path
+         d="m 1267.7785,-770.46954 h -37.9293 l -46.6214,70.32723 h -1.1853 l -45.0411,-70.32723 h -41.09 l 68.3517,93.24285 v 1.18529 l -70.7223,96.79872 h 37.9293 l 49.7822,-75.85859 h 1.1853 l 49.7822,75.85859 h 41.09 l -72.3027,-98.37911 v -1.18529 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
+         id="path4687" />
+    </g>
+    <g
+       aria-label="O"
+       transform="scale(0.95067318,1.0518862)"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:367.48727417px;line-height:125%;font-family:Carlito;-inkscape-font-specification:Carlito;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       xml:space="preserve"
-       inkscape:export-filename="/home/tim/dev/nix/logo/poll/text.png"
-       inkscape:export-xdpi="67.440002"
-       inkscape:export-ydpi="67.440002"
-       transform="scale(0.95067318,1.0518862)"><tspan
-         y="-547.966"
-         x="1314.3683"
-         id="tspan5358"
-         sodipodi:role="line"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur">O</tspan></text>
-    <text
-       inkscape:export-ydpi="67.440002"
-       inkscape:export-xdpi="67.440002"
-       inkscape:export-filename="/home/tim/dev/nix/logo/poll/text.png"
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:386.55480957px;line-height:125%;font-family:Carlito;-inkscape-font-specification:Carlito;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="1479.1118"
-       y="-577.90314"
-       id="text5364"
-       sodipodi:linespacing="125%"><tspan
+       id="text5356">
+      <path
+         d="m 1468.5915,-800.79725 c -66.1477,0 -120.5358,48.14083 -120.5358,128.25306 0,80.11223 54.3881,128.25306 120.5358,128.25306 66.1477,0 120.5359,-48.14083 120.5359,-128.25306 0,-80.11223 -54.3882,-128.25306 -120.5359,-128.25306 z m 0,24.98914 c 49.2433,0 86.727,36.74872 86.727,103.26392 0,66.5152 -37.4837,103.26392 -86.727,103.26392 -49.2433,0 -86.727,-36.74872 -86.727,-103.26392 0,-66.5152 37.4837,-103.26392 86.727,-103.26392 z"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
-         sodipodi:role="line"
-         x="1479.1118"
-         y="-577.90314"
-         id="tspan5368">S</tspan></text>
+         id="path4680" />
+    </g>
+    <g
+       aria-label="S"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:386.55480957px;line-height:125%;font-family:Carlito;-inkscape-font-specification:Carlito;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text5364">
+      <path
+         d="m 1523.761,-773.88643 c 0,37.10927 19.3277,57.21012 64.1681,75.37819 34.4034,13.91598 48.3193,26.28573 48.3193,51.79835 0,30.92438 -25.126,46.38657 -58.3697,46.38657 -17.395,0 -37.1093,-2.70588 -58.7564,-10.05042 l -3.479,26.67228 c 18.9412,6.95799 39.8152,9.66387 60.6891,9.66387 51.7984,0 95.0925,-26.28573 95.0925,-79.24374 0,-36.7227 -22.4202,-54.50422 -67.6471,-72.6723 -30.1512,-11.9832 -44.8403,-24.73951 -44.8403,-51.41179 0,-25.89917 22.4202,-40.2017 50.6387,-40.2017 16.6218,0 34.7899,4.2521 47.5462,9.27732 l 3.479,-26.28573 c -14.6891,-6.18488 -32.8572,-9.27732 -52.958,-9.27732 -47.5463,0 -83.8824,27.4454 -83.8824,69.96642 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Vegur;-inkscape-font-specification:Vegur"
+         id="path4677" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
The logo had a soft-coded font in it, which meant that people downloading the logo first had to install that font to render the logo correctly. If not the software (browser, office suite, etc) would fall back to some random font on the system - which may not look very nice and certainly is not likely to result in what was intended by the designer. 

The text part of the logo has been converted to paths, thus avoiding all problems and resulting in a pretty logo everywhere.