### PR TITLE
Wrap option description in <para> instead of <div>

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -259,7 +259,7 @@ function showOption() {
 
   var details = $('#details-template').clone().removeAttr('id').show();
 
-  var x = $.parseXML('<xml xmlns:xlink="http://www.w3.org/1999/xlink"><div>' + opt.description + '</div></xml>');
+  var x = $.parseXML('<xml xmlns:xlink="http://www.w3.org/1999/xlink"><para>' + opt.description + '</para></xml>');
   $('.description', details).empty().append($(x).text());
 
   if ('default' in opt)


### PR DESCRIPTION
Wrap option description in `<para>` instead of `<div>` because some of them expect to be able to close wrapping `<para>` tags and error because of a tag mismatch. Example: https://nixos.org/nixos/options.html#boot.loader.grub.efiinstallasremovable