### PR TITLE
NixOS option search improvements

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -123,7 +123,16 @@ function refilter() {
       return words.every(match);
     });
 
-    document.location.hash = words.join(' ').replace(/ +/, '+');
+    var encodedWords = words.map(function(value) {
+      return encodeURIComponent(value);
+    });
+    var hash = encodedWords.join('+');
+    while (document.getElementById(hash)) {
+      hash = '+' + hash;
+    }
+    history.replaceState({}, '', '#' + hash);
+  } else {
+    history.replaceState({}, '', '#');
   }
 
   curPage = 0;
@@ -294,12 +303,33 @@ $.ajax({
   success: function(data) {
     optionData = data;
 
-    var query = document.location.hash.replace(/^#/, '').replace(/\+/, ' ');
-    if (query.length && query.length > 0 ){ $('#search').val(query); }
-    refilter();
+    var lastHash;
+    var hashChanged = true;
+
+    function updateQuery() {
+      var query = decodeURIComponent(document.location.hash.replace(/^#\+*/, '').replace(/\+/g, ' '));
+      if (query.length && query.length > 0 ){ $('#search').val(query); } else { $('#search').val('') };
+      refilter();
+      lastHash = location.hash || '#';
+    }
+
+    $(window).on('popstate', updateQuery);
+
+    updateQuery();
 
     $('#search').on('input', function() {
+      if (hashChanged) {
+        history.pushState({}, '', location.hash || '#');
+        hashChanged = false;
+      }
       refilter();
+    });
+    $('#search').on('change', function() {
+      var hash = location.hash || '#';
+      if (lastHash != hash) {
+        hashChanged = true;
+        lastHash = hash;
+      }
     });
   }
 });


### PR DESCRIPTION
Fixes a bunch of issues:
- Every time the query changed by a character a new entry would be put in history.
- The URL would not update after the last character was removed from the search box.
- If you typed in a valid element id e.g. `search` it would try to jump to that element (which misaligns the search box).
- If you typed in` +` and reloaded the page it would be converted into a space.
- If the query had more then two words it would not replace the additional spaces with pluses.