### PR TITLE
Add a link to the nixos wiki on Archive.org

### DIFF
--- a/nixos/wiki.html
+++ b/nixos/wiki.html
@@ -29,3 +29,9 @@
 
 <p>You can see the conversation about the wiki, and future plans at
   <a href="https://github.com/NixOS/nixpkgs/issues/22599">NixOS/nixpkgs#22599</a>.</p>
+
+<p>Additionally, the old, out of date, and generally inaccurate NixOS
+  Wiki can be viewed on Archive.org at
+  https://web.archive.org/web/20160829180446/https://nixos.org/wiki/Special:AllPages.
+  As the wiki has been readonly since before 2016-08-29, this is the
+  most recent version.</p>


### PR DESCRIPTION
Perhaps not 100% of the content was utterly bad. Add this link for the adventure seekers, hopefully with enough warning that it is possibly broken. 