### PR TITLE
Display license information in nix package search

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -341,3 +341,21 @@ div.docbook div.toc {
 div.docbook div.toc dd {
     margin-left: 2em;
 }
+
+.license ul {
+    margin-left: 0px;
+}
+
+.license li {
+    display: inline;
+    list-style: none;
+    content: ", ";
+}
+
+.license li:after {
+    content: ", ";
+}
+
+.license li:last-child:after {
+    content: "";
+}

--- a/nixos/packages.tt
+++ b/nixos/packages.tt
@@ -153,6 +153,45 @@ function refilter() {
   updateTable();
 };
 
+// Try to figure out a human-readable name for a license object.
+// Use the SPDX ID if present; failing that try the long or short names. If all
+// else fails fall back on URL.
+function licenseName(license) {
+  return license.spdxId
+    || license.fullName
+    || license.shortName
+    || license.url
+    || "Licence name missing!";
+}
+
+// Given a license, or array of licenses, generate and return a DOM node
+// containing information about it/them.
+// A license can be a plain string (in which case it returns the string itself
+// as a text node), or a license object, in which case it attempts to construct
+// a link to the license's URL (if specified).
+function licenseInfo(license) {
+  if (typeof license == 'string') {
+    return document.createTextNode(license);
+  }
+  if (Array.isArray(license)) {
+    return license
+      .map(licenseInfo)
+      .map(function(license) { return $("<li>").append(license) })
+      .reduce(function(ul, li) {
+        return ul.append(li);
+      }, $("<ul>"));
+  }
+
+  if (license.url) {
+    return $("<a>", {
+      text: licenseName(license),
+      href: license.url,
+    });
+  } else {
+    return document.createTextNode(licenseName(license));
+  }
+}
+
 function showPackage() {
   var pkgName = $(this).attr('pkgName');
   var info = packageData[pkgName];
@@ -192,10 +231,10 @@ function showPackage() {
   if (typeof homepage == 'string')
     $('.homepage', details).empty().append($('<a/>', { href: homepage }).text(homepage));
 
-  // FIXME #49: hande lists and attrsets of licenses.
   var license = info['meta']['license'];
-  if (typeof license == 'string')
-    $('.license', details).empty().text(license);
+  if (license) {
+    $('.license', details).empty().append(licenseInfo(license));
+  }
 
   var maintainers = info['meta']['maintainers'];
   if (Array.isArray(maintainers) && maintainers.length > 0)


### PR DESCRIPTION
A lot of packages have a license object or array thereof rather than a
license string. With this patch, the package search will display all
listed licences, as links to their SPDX page.

Signed-off-by: Ben Kelly <bk@ancilla.ca>