### PR TITLE
Verified install steps

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -89,6 +89,16 @@ pre {
     box-shadow: 0.1em 0.1em 0.5em #e0e0e0;
 }
 
+.command:before {
+    color: #999;
+    content: " $ ";
+}
+
+.nix-shell-command:before {
+    color: #999;
+    content: " [nix-shell]$ ";
+}
+
 div.main li {
     margin-bottom: 0.5em;
 }

--- a/nix/about.tt
+++ b/nix/about.tt
@@ -188,7 +188,7 @@ href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/
 Nix expression</a>:</p>
 
 <pre>
-<span class="command">nix-shell '&lt;nixpkgs>' -A pan</span>
+<span class="command">nix-shell '&lt;nixpkgs&gt;' -A pan</span>
 </pre>
 
 <p>You’re then dropped into a shell where you can edit, build and test

--- a/nix/about.tt
+++ b/nix/about.tt
@@ -88,8 +88,8 @@ there after an upgrade.  This means that you can <em>roll back</em> to
 the old version:</p>
 
 <pre class="code">
-<span class="muted">$</span> nix-env --upgrade <em>some-packages</em>
-<span class="muted">$</span> nix-env --rollback
+<span class="command">nix-env --upgrade <em>some-packages</em></span>
+<span class="command">nix-env --rollback</span>
 </pre>
 
 
@@ -98,7 +98,7 @@ the old version:</p>
 <p>When you uninstall a package like this…</p>
 
 <pre class="code">
-<span class="muted">$</span> nix-env --uninstall firefox
+<span class="command">nix-env --uninstall firefox</span>
 </pre>
 
 <p>the package isn’t deleted from the system right away (after all,
@@ -107,7 +107,7 @@ other users).  Instead, unused packages can be deleted safely by
 running the <em>garbage collector</em>:</p>
 
 <pre class="code">
-<span class="muted">$</span> nix-collect-garbage
+<span class="command">nix-collect-garbage</span>
 </pre>
 
 <p>This deletes all packages that aren’t in use by any user profile or
@@ -137,7 +137,7 @@ store.</p>
 source, so an installation action like</p>
 
 <pre class="code">
-<span class="muted">$</span> nix-env --install firefox
+<span class="command">nix-env --install firefox</span>
 </pre>
 
 <p><em>could</em> cause quite a bit of build activity, as not only
@@ -188,18 +188,18 @@ href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/applications/networking/
 Nix expression</a>:</p>
 
 <pre>
-<span class="muted">$</span> nix-shell '&lt;nixpkgs>' -A pan
+<span class="command">nix-shell '&lt;nixpkgs>' -A pan</span>
 </pre>
 
 <p>You’re then dropped into a shell where you can edit, build and test
 the package:</p>
 
 <pre>
-<span class="muted">[nix-shell]$</span> tar xf $src
-<span class="muted">[nix-shell]$</span> cd pan-*
-<span class="muted">[nix-shell]$</span> ./configure
-<span class="muted">[nix-shell]$</span> make
-<span class="muted">[nix-shell]$</span> ./pan/gui/pan
+<span class="nix-shell-command">tar xf $src</span>
+<span class="nix-shell-command">cd pan-*</span>
+<span class="nix-shell-command">./configure</span>
+<span class="nix-shell-command">make</span>
+<span class="nix-shell-command">./pan/gui/pan</span>
 </pre>
 
 <p>Since Nix packages are reproducible and have complete dependency

--- a/nix/download.tt
+++ b/nix/download.tt
@@ -7,17 +7,17 @@
 on Linux and Mac OS X is to run the following in a shell (as a user
 other than <tt>root</tt>):
 
-<pre><span class="muted">$</span> curl <a href="[%root%]nix/install">https://nixos.org/nix/install</a> | sh</pre>
+<pre><span class="command">curl <a href="[%root%]nix/install">https://nixos.org/nix/install</a> | sh</span></pre>
 
 Make sure to follow the instructions output by the script.
 
 You may want to verify the integrity of the installation script using GPG:
 
 <pre>
-<span class="muted">$</span> curl -O <a href="[%root%]nix/install">https://nixos.org/nix/install</a>
-<span class="muted">$</span> curl -O <a href="[%root%]nix/install.sig">https://nixos.org/nix/install.sig</a>
-<span class="muted">$</span> gpg2 --verify ./install.sig
-<span class="muted">$</span> sh ./install
+<span class="command">curl -O <a href="[%root%]nix/install">https://nixos.org/nix/install</a></span>
+<span class="command">curl -O <a href="[%root%]nix/install.sig">https://nixos.org/nix/install.sig</a></span>
+<span class="command">gpg2 --verify ./install.sig</span>
+<span class="command">sh ./install</span>
 </pre>
 
 The <a href="[%root%]edolstra.gpg">signing key</a> has fingerprint <tt>B541 D553 0127 0E0B CF15  CA5D 8170 B472 6D71 98DE</tt>.</p>

--- a/nix/download.tt
+++ b/nix/download.tt
@@ -4,31 +4,36 @@
 
 <p>The latest and recommended version of Nix is
 <strong>[%latestNixVersion%]</strong>. The quickest way to install it
-on Linux and Mac OS X is to run the following in a shell (as a user
-other than <tt>root</tt>):
-
-<pre><span class="command">curl <a href="[%root%]nix/install">https://nixos.org/nix/install</a> | sh</span></pre>
-
-Make sure to follow the instructions output by the script.
-
-You may want to verify the integrity of the installation script using GPG:
+on Linux and macOS is to run the following in a shell (as a user
+other than <tt>root</tt>):</p>
 
 <pre>
-<span class="command">curl -O <a href="[%root%]nix/install">https://nixos.org/nix/install</a></span>
-<span class="command">curl -O <a href="[%root%]nix/install.sig">https://nixos.org/nix/install.sig</a></span>
-<span class="command">gpg2 --verify ./install.sig</span>
-<span class="command">sh ./install</span>
+<span class="command">curl https://nixos.org/nix/install | sh</span>
 </pre>
 
-The <a href="[%root%]edolstra.gpg">signing key</a> has fingerprint <tt>B541 D553 0127 0E0B CF15  CA5D 8170 B472 6D71 98DE</tt>.</p>
+<p>Make sure to follow the instructions output by the script.</p>
+
+<h3>GPG Verification</h3>
+<p>You may want to verify the integrity of the installation script
+using GPG:</p>
+
+<pre>
+<span class="command">curl -o install-nix-[%latestNixVersion%] https://nixos.org/nix/install</span>
+<span class="command">curl -o install-nix-[%latestNixVersion%].sig https://nixos.org/nix/install.sig</span>
+<span class="command">gpg2 --recv-keys B541D55301270E0BCF15CA5D8170B4726D7198DE</span>
+<span class="command">gpg2 --verify ./install-nix-[%latestNixVersion%].sig</span>
+<span class="command">sh ./install-nix-[%latestNixVersion%]</span>
+</pre>
+
+<p>The <a href="[%root%]edolstra.gpg">signing key</a> has fingerprint <tt>B541 D553 0127 0E0B CF15  CA5D 8170 B472 6D71 98DE</tt>.
+It is also available <a href="https://github.com/NixOS/nixos-homepage/blob/master/edolstra.gpg">on GitHub</a>.</p>
 
 <p>The installation script requires that you have <tt>sudo</tt> access
-to <tt>root</tt>, unless the directory <tt>/nix</tt> already exists
-and is writable by you. You can uninstall Nix simply by running <tt>rm
+to <tt>root</tt>. You can uninstall Nix simply by running <tt>rm
 -rf /nix</tt>. See <a href="[%nixManual%]#chap-installation">the
 manual</a> for more information.</p>
 
-<p>The following are also available:
+<p>The following are also available:</p>
 
 <ul>
 
@@ -51,8 +56,6 @@ manual</a> for more information.</p>
 
 </ul>
 
-</p>
-
 </section>
 
 
@@ -64,10 +67,7 @@ href="../hydra">continuous build system</a>:</p>
 <ul>
   <li><a
   href="https://hydra.nixos.org/job/nix/trunk/release#tabs-constituents">The
-  latest development release of Nix</a> (<a
-  href="https://hydra.nixos.org/job/nix/trunk/release/latest-finished/eval/job/tarball/download-by-type/file/source-dist">source
-  tarball</a> and <a
-  href="https://hydra.nixos.org/job/nix/trunk/release/latest-finished/eval/job/tarball/download-by-type/doc/manual">manual</a>)</li>
+  latest development release of Nix</a></li>
 </ul>
 
 </section>

--- a/nix/index.tt
+++ b/nix/index.tt
@@ -25,7 +25,7 @@
     Nix</strong> is to run the following shell command (as a user
     other than <tt>root</tt>):</p>
 
-    <pre><span class="muted">$</span> curl https://nixos.org/nix/install | sh</pre>
+    <pre><span class="command">curl https://nixos.org/nix/install | sh</span></pre>
 
     <p>This script will download a distribution-independent binary
     tarball containing Nix and its dependencies, and unpack it in

--- a/nix/index.tt
+++ b/nix/index.tt
@@ -21,7 +21,7 @@
 
   [% WRAPPER makePopover title="<i class='fa fa-cloud-download'></i> Get Nix" %]
 
-    <p>On Linux and Mac OS X, the <strong>easiest way to install
+    <p>On Linux and macOS, the <strong>easiest way to install
     Nix</strong> is to run the following shell command (as a user
     other than <tt>root</tt>):</p>
 
@@ -31,7 +31,10 @@
     tarball containing Nix and its dependencies, and unpack it in
     <tt>/nix</tt>.</p>
 
-    <p>Source tarballs and more installation information are <a
+    <p><strong>Want a GPG signature?</strong></p>
+
+    <p>GPG verification instructions, source tarballs and more
+    installation information are <a
     href="[%root%]nix/download.html">available</a>.</p>
 
   [% END %]

--- a/nixops/index.tt
+++ b/nixops/index.tt
@@ -43,8 +43,8 @@ should be instantiated (in this case, as VirtualBox virtual machines
 running on your desktop). You can then run:</p>
 
 <pre>
-<span class="muted">$</span> nixops create -d simple network.nix
-<span class="muted">$</span> nixops deploy -d simple
+<span class="command">nixops create -d simple network.nix</span>
+<span class="command">nixops deploy -d simple</span>
 </pre>
 
 <p>This will create the EC2 instances, and then build, upload and
@@ -79,7 +79,7 @@ deployment.region = "eu-west-1";
 running:</p>
 
 <pre>
-<span class="muted">$</span> nix-env -i nixops
+<span class="command">nix-env -i nixops</span>
 </pre>
 
 <p>You can also get the latest development version; see the <a

--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -9,14 +9,14 @@
     well):</p>
 
 <pre>
-<span class="muted">$</span> git clone git://github.com/NixOS/nixpkgs.git
+<span class="command">git clone git://github.com/NixOS/nixpkgs.git</span>
 </pre>
 
     <p>After making modifications to the sources, you can use them as
     follows:</p>
 
 <pre>
-<span class="muted">$</span> nixos-rebuild switch -I nixpkgs=/path/to/my/nixpkgs
+<span class="command">nixos-rebuild switch -I nixpkgs=/path/to/my/nixpkgs</span>
 </pre>
 
 <p>If you think your changes are useful to the rest of humanity, then

--- a/nixos/packages.tt
+++ b/nixos/packages.tt
@@ -33,7 +33,7 @@
     <tr>
       <th>Install command:</th>
       <td>
-        <tt><span class="muted">$</span> nix-env -iA nixos.<span class='attrname'></span></tt> <em class='muted'>(NixOS channel)</em>
+        <tt><span class="command">nix-env -iA nixos.<span class='attrname'></span></span></tt> <em class='muted'>(NixOS channel)</em>
       </td>
     </tr>
     <tr>

--- a/nixos/packages.tt
+++ b/nixos/packages.tt
@@ -1,18 +1,18 @@
-[% WRAPPER layout.tt title='Search NixOS packages' menu='nixos' %]
+[% WRAPPER layout.tt title="Search NixOS packages" menu="nixos" %]
 
 <p>
-  <input name='query' type='text' class='search-query span3'
-         placeholder='Search by name or description'
-         id='search' value='' autofocus='autofocus'/>
+  <input name="query" type="text" class="search-query span3"
+         placeholder="Search by name or description"
+         id="search" value="" autofocus="autofocus"/>
 </p>
 
 <hr />
 
-<p><em id='how-many'>Loading…</em></p>
+<p><em id="how-many">Loading…</em></p>
 
-<div id='results-wrapper' class='hide'>
+<div id="results-wrapper" class="hide">
 
-<table class='table table-hover' id='search-results'>
+<table class="table table-hover" id="search-results">
   <thead>
     <tr>
       <th>Package name</th>
@@ -28,37 +28,37 @@
 
 </div>
 
-<div id='details-template' class='search-details hide'>
+<div id="details-template" class="search-details hide">
   <table>
     <tr>
       <th>Install command:</th>
       <td>
-        <tt><span class="command">nix-env -iA nixos.<span class='attrname'></span></span></tt> <em class='muted'>(NixOS channel)</em>
+        <tt><span class="command">nix-env -iA nixos.<span class="attrname"></span></span></tt> <em class="muted">(NixOS channel)</em>
       </td>
     </tr>
     <tr>
       <th>Nix expression:</th>
-      <td class='nix-expr'><em>Not specified</em></td>
+      <td class="nix-expr"><em>Not specified</em></td>
     </tr>
     <tr>
       <th>Platforms:</th>
-      <td class='platforms'><em>Not specified</em></td>
+      <td class="platforms"><em>Not specified</em></td>
     </tr>
     <tr>
       <th>Homepage:</th>
-      <td class='homepage'><em>Not specified</em></td>
+      <td class="homepage"><em>Not specified</em></td>
     </tr>
     <tr>
       <th>License:</th>
-      <td class='license'><em>Not specified</em></td>
+      <td class="license"><em>Not specified</em></td>
     </tr>
     <tr>
       <th>Maintainers:</th>
-      <td class='maintainers'><em>Not specified</em></td>
+      <td class="maintainers"><em>Not specified</em></td>
     </tr>
     <tr>
-      <th style='width: 10em'>Long description:</th>
-      <td class='long-description'><em>Not specified</em></td>
+      <th style="width: 10em">Long description:</th>
+      <td class="long-description"><em>Not specified</em></td>
     </tr>
   </table>
 </div>
@@ -80,11 +80,11 @@ function updateTable() {
   if (0 > curPage) curPage = 0;
   if (curPage > lastPage) curPage = lastPage;
 
-  var body = $('#search-results tbody');
-  $('tr', body).remove();
+  var body = $("#search-results tbody");
+  $("tr", body).remove();
 
-  $('.back').toggleClass('disabled', curPage == 0);
-  $('.forward').toggleClass('disabled', curPage >= lastPage);
+  $(".back").toggleClass("disabled", curPage == 0);
+  $(".forward").toggleClass("disabled", curPage >= lastPage);
 
   var start = curPage * resultsPerPage;
   var end = start + resultsPerPage;
@@ -92,45 +92,45 @@ function updateTable() {
   res = results.slice(start, end);
 
   if (results.length == 0) {
-    $('#results-wrapper').hide();
-    $('#how-many').text('No matching packages were found.');
+    $("#results-wrapper").hide();
+    $("#how-many").text("No matching packages were found.");
     return;
   }
 
-  $('#how-many').text(
-    'Showing results ' + (start + 1) + '-' + end + ' of ' + results.length + '.');
+  $("#how-many").text(
+    "Showing results " + (start + 1) + "-" + end + " of " + results.length + ".");
 
   var odd = true;
   res.forEach(function(pkgName) {
     var info = packageData[pkgName];
-    body.append($('<tr/>', { pkgName: pkgName })
-      .addClass('result')
-      .addClass(odd ? 'odd' : 'even')
+    body.append($("<tr/>", { pkgName: pkgName })
+      .addClass("result")
+      .addClass(odd ? "odd" : "even")
       .click(showPackage)
-      .append($('<td/>', { text: info['name'] }))
-      .append($('<td/>', { text: pkgName }))
-      .append($('<td/>', { text: info['meta']['description'] }))
+      .append($("<td/>", { text: info["name"] }))
+      .append($("<td/>", { text: pkgName }))
+      .append($("<td/>", { text: info["meta"]["description"] }))
     );
     odd = !odd;
   });
 
-  $('#results-wrapper').show();
+  $("#results-wrapper").show();
 };
 
 function refilter() {
   var attrs = Object.keys(packageData);
 
-  var words = $('#search').val().toLowerCase().split(/ +/).filter(Boolean);
+  var words = $("#search").val().toLowerCase().split(/ +/).filter(Boolean);
 
   if (words.length > 0) {
     attrs = attrs.filter(function (attr) {
       var info = packageData[attr];
-      var description = info['meta']['description'] || '';
-      var longDescription = info['meta']['longDescription'] || '';
+      var description = info["meta"]["description"] || "";
+      var longDescription = info["meta"]["longDescription"] || "";
 
       function match(word) {
         return (attr.toLowerCase().indexOf(word) != -1
-          || info['name'].toLowerCase().indexOf(word) != -1
+          || info["name"].toLowerCase().indexOf(word) != -1
           || description.toLowerCase().indexOf(word) != -1
           || longDescription.toLowerCase().indexOf(word) != -1);
       };
@@ -140,8 +140,8 @@ function refilter() {
   }
 
   results = attrs.sort(function(a, b) {
-    var ia = packageData[a]['name'].toLowerCase();
-    var ib = packageData[b]['name'].toLowerCase();
+    var ia = packageData[a]["name"].toLowerCase();
+    var ib = packageData[b]["name"].toLowerCase();
     if (ia < ib) return -1;
     if (ia > ib) return 1;
     return 0;
@@ -170,7 +170,7 @@ function licenseName(license) {
 // as a text node), or a license object, in which case it attempts to construct
 // a link to the license's URL (if specified).
 function licenseInfo(license) {
-  if (typeof license == 'string') {
+  if (typeof license == "string") {
     return document.createTextNode(license);
   }
   if (Array.isArray(license)) {
@@ -193,77 +193,77 @@ function licenseInfo(license) {
 }
 
 function showPackage() {
-  var pkgName = $(this).attr('pkgName');
+  var pkgName = $(this).attr("pkgName");
   var info = packageData[pkgName];
 
-  var expanded = $(this).attr('expanded');
-  $('tr.details', $(this).parent()).remove();
-  $('tr', $(this).parent()).removeAttr('expanded');
+  var expanded = $(this).attr("expanded");
+  $("tr.details", $(this).parent()).remove();
+  $("tr", $(this).parent()).removeAttr("expanded");
   if (expanded) return;
 
-  var details = $('#details-template').clone().removeAttr('id').show();
+  var details = $("#details-template").clone().removeAttr("id").show();
 
-  $('.attrname', details).text(pkgName);
+  $(".attrname", details).text(pkgName);
 
-  var nixExpr = info['meta']['position'];
-  if (typeof nixExpr == 'string') {
-    var n = nixExpr.lastIndexOf(':');
+  var nixExpr = info["meta"]["position"];
+  if (typeof nixExpr == "string") {
+    var n = nixExpr.lastIndexOf(":");
     var file = nixExpr.slice(0, n);
     var line = nixExpr.slice(n + 1);
-    var url = 'https://github.com/NixOS/nixpkgs/blob/' + nixpkgsCommit + '/' + file + '#L' + line;
-    $('.nix-expr', details).empty().append($('<a/>', { href: url }).text(file));
+    var url = "https://github.com/NixOS/nixpkgs/blob/" + nixpkgsCommit + "/" + file + "#L" + line;
+    $(".nix-expr", details).empty().append($("<a/>", { href: url }).text(file));
   }
 
-  var platforms = info['meta']['platforms'];
+  var platforms = info["meta"]["platforms"];
   if (Array.isArray(platforms) && platforms.length > 0) {
-    var p = $('.platforms', details).empty();
+    var p = $(".platforms", details).empty();
     var first = true;
     platforms.forEach(function (system) {
-      if (system != 'i686-linux' && system != 'x86_64-linux') return;
-      if (!first) p.append(document.createTextNode(', '));
+      if (system != "i686-linux" && system != "x86_64-linux") return;
+      if (!first) p.append(document.createTextNode(", "));
       first = false;
-      var url = 'https://hydra.nixos.org/job/nixos/[%latestNixOSBranch%]/nixpkgs.' + pkgName + '.' + system;
-      p.append($('<a/>', { href: url }).append($('<tt/>').text(system)));
+      var url = "https://hydra.nixos.org/job/nixos/[%latestNixOSBranch%]/nixpkgs." + pkgName + "." + system;
+      p.append($("<a/>", { href: url }).append($("<tt/>").text(system)));
     });
   }
 
-  var homepage = info['meta']['homepage'];
-  if (typeof homepage == 'string')
-    $('.homepage', details).empty().append($('<a/>', { href: homepage }).text(homepage));
+  var homepage = info["meta"]["homepage"];
+  if (typeof homepage == "string")
+    $(".homepage", details).empty().append($("<a/>", { href: homepage }).text(homepage));
 
-  var license = info['meta']['license'];
+  var license = info["meta"]["license"];
   if (license) {
-    $('.license', details).empty().append(licenseInfo(license));
+    $(".license", details).empty().append(licenseInfo(license));
   }
 
-  var maintainers = info['meta']['maintainers'];
+  var maintainers = info["meta"]["maintainers"];
   if (Array.isArray(maintainers) && maintainers.length > 0)
     // FIXME: check whether elements are strings.
-    $('.maintainers', details).empty().text(maintainers.join(', '));
+    $(".maintainers", details).empty().text(maintainers.join(", "));
 
-  var longDescription = info['meta']['longDescription'];
-  if (typeof longDescription == 'string')
-    $('.long-description', details).empty().addClass("pre").text(longDescription);
+  var longDescription = info["meta"]["longDescription"];
+  if (typeof longDescription == "string")
+    $(".long-description", details).empty().addClass("pre").text(longDescription);
 
-  $(this).after($('<tr/>')
-    .addClass('details')
-    .append($('<td/>', { colspan: 3 })
+  $(this).after($("<tr/>")
+    .addClass("details")
+    .append($("<td/>", { colspan: 3 })
       .append(details))
-  ).attr('expanded', 1);
+  ).attr("expanded", 1);
 };
 
 $.ajax({
-  url: '[%root%]nixpkgs/packages.json.gz',
-  type: 'GET',
-  dataType: 'json',
-  error: function(a, status, error) { alert('Failed to get package data [' + status + ']: ' + error); },
+  url: "[%root%]nixpkgs/packages.json.gz",
+  type: "GET",
+  dataType: "json",
+  error: function(a, status, error) { alert("Failed to get package data [" + status + "]: " + error); },
   success: function(data) {
     nixpkgsCommit = data.commit;
     packageData = data.packages;
 
     refilter();
 
-    $('#search').on('input', function() {
+    $("#search").on("input", function() {
       refilter();
     });
   }


### PR DESCRIPTION
First commit improves the places a shell command is on the website, where the `$` of the prompt is placed with CSS. This means that when you copy-paste the line it is impossible to accidentally copy the `$` of the shell.

Second commit creates a `.tt` file containing the sha sums of the nix/install file, making it available in templates.

Third commit updates the "quick" install popup thing to include a sha verification, and a signature verification. I think it is valuable to put these verification steps right up front in order to:

1. demonstrate we care
2. demonstrate they're available, without having to click to the "additional options" page

however doesn't put GPG in the mandatory path for users unless they would like to use it. Additionally:

1. this PR adds a second link to the GPG key, on a secondary domain if someone truly paranoid would like to validate the signing key matches in both places, and
2. adds the `gpg2 --recv-keys` line right there, to make it trivially easy to follow.

Note the light trickery in the sha256 validation line:

> echo "aa37b53577c96ad745c0d84a871de3e398a1cd9c32987d0e662d92c56cdcc4ef  install-nix-1.11.12" | (shasum -p 256 || sha256sum -c) 2> /dev/null

If shasum doesn't exist, it'll fall back to sha256sum automatically.

 All in all, the changes end up looking like this:

![screenshot-2017-7-16 nix_ the purely functional package manager](https://user-images.githubusercontent.com/76716/28250705-441178f6-6a3d-11e7-8888-9102fa495098.png)

This work is inspired by trying to make my work's security team happy enough with the instructions.

Here is the output of a trial run of these quick instructions:

```
grahamc@Morbo> curl -o install-nix-1.11.12 https://nixos.org/nix/install                                                                % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2358  100  2358    0     0   5937      0 --:--:-- --:--:-- --:--:--  5954

grahamc@Morbo> echo "aa37b53577c96ad745c0d84a871de3e398a1cd9c32987d0e662d92c56cdcc4ef  install-nix-1.11.12" | (shasum -p 256 || sha256sum -c) 2> /dev/null
install-nix-1.11.12: OK

grahamc@Morbo> gpg2 --recv-keys B541D55301270E0BCF15CA5D8170B4726D7198DE                                                              gpg: key 0x8170B4726D7198DE: "Eelco Dolstra <edolstra@gmail.com>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1

grahamc@Morbo> curl -o install-nix-1.11.12.sig https://nixos.org/nix/install.sig                                                        % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   488  100   488    0     0   1349      0 --:--:-- --:--:-- --:--:--  1359

grahamc@Morbo> gpg2 --verify ./install-nix-1.11.12.sig                                                                                gpg: assuming signed data in './install-nix-1.11.12'
gpg: Signature made Thu 13 Jul 2017 09:44:48 AM EDT
gpg:                using RSA key B541D55301270E0BCF15CA5D8170B4726D7198DE
gpg: Good signature from "Eelco Dolstra <edolstra@gmail.com>" [unknown]
gpg:                 aka "Eelco Dolstra <eelco.dolstra@logicblox.com>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: B541 D553 0127 0E0B CF15  CA5D 8170 B472 6D71 98DE
```