### PR TITLE
Nix pills

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ $(HYDRA_MANUAL_OUT): $(HYDRA_MANUAL_IN) bootstrapify-docbook.sh bootstrapify-doc
 	ln -sfn manual.html $(HYDRA_MANUAL_OUT)/index.html
 
 $(HYDRA_MANUAL_IN):
-	path=$$(curl -H 'Accept: application/json' http://hydra.nixos.org/build/41892729 | jq -re '.buildoutputs.out.path') && \
+	path=$$(curl -LH 'Accept: application/json' https://hydra.nixos.org/build/41892729 | jq -re '.buildoutputs.out.path') && \
 	nix-store -r $$path && \
 	ln -sfn $$path/share/doc/hydra $(HYDRA_MANUAL_IN)
 

--- a/Makefile
+++ b/Makefile
@@ -36,13 +36,13 @@ $(NIXOS_MANUAL_IN):
 
 ### Prettify the Nix Pills
 
-NIX_PILLS_MANUAL_IN = nix-pills-raw
-NIX_PILLS_MANUAL_OUT = nix-pills
+NIX_PILLS_MANUAL_IN = nixos/nix-pills-raw
+NIX_PILLS_MANUAL_OUT = nixos/nix-pills
 
 all: $(NIX_PILLS_MANUAL_OUT)
 
 $(NIX_PILLS_MANUAL_OUT): $(NIX_PILLS_MANUAL_IN) bootstrapify-docbook.sh bootstrapify-docbook.xsl layout.tt common.tt
-	./bootstrapify-docbook.sh $(NIX_PILLS_MANUAL_IN) $(NIX_PILLS_MANUAL_OUT) 'Nix Pills' nix-pills https://github.com/NixOS/nix-pills
+	./bootstrapify-docbook.sh $(NIX_PILLS_MANUAL_IN) $(NIX_PILLS_MANUAL_OUT) 'Nix Pills' nixos https://github.com/NixOS/nix-pills
 
 $(NIX_PILLS_MANUAL_IN):
 	path=$$(curl -LH 'Accept: application/json' https://hydra.nixos.org/job/nix-pills/master/html-split/latest | jq -re '.buildoutputs.out.path') && \

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,21 @@ $(NIXOS_MANUAL_IN):
 	nix-build -o $@ '<nixpkgs/nixos>' -I nixpkgs=$(NIXPKGS) \
 	  -A config.system.build.manual.manual --arg configuration '{ fileSystems."/".device = "/dummy"; }'
 
+### Prettify the Nix Pills
+
+NIX_PILLS_MANUAL_IN = nix-pills-raw
+NIX_PILLS_MANUAL_OUT = nix-pills
+
+all: $(NIX_PILLS_MANUAL_OUT)
+
+$(NIX_PILLS_MANUAL_OUT): $(NIX_PILLS_MANUAL_IN) bootstrapify-docbook.sh bootstrapify-docbook.xsl layout.tt common.tt
+	./bootstrapify-docbook.sh $(NIX_PILLS_MANUAL_IN) $(NIX_PILLS_MANUAL_OUT) 'Nix Pills' nix-pills https://github.com/NixOS/nix-pills
+
+$(NIX_PILLS_MANUAL_IN):
+	path=$$(curl -LH 'Accept: application/json' https://hydra.nixos.org/job/nix-pills/master/html-split/latest | jq -re '.buildoutputs.out.path') && \
+	nix-store -r $$path && \
+	ln -sfn $$path/share/doc/nix-pills $(NIX_PILLS_MANUAL_IN)
+
 
 ### Prettify the Nix manual.
 

--- a/bootstrapify-docbook.sh
+++ b/bootstrapify-docbook.sh
@@ -19,7 +19,7 @@ mkdir -p "$outDirTmp"
     elif [[ "$fn" =~ .html$ ]]; then
         xsltproc --nonet bootstrapify-docbook.xsl "$inDir/$fn" > "$outDirTmp/$fn.in"
         tpage --pre_chomp --post_chomp \
-            --define root=`echo "$outDir/$fn" | sed -e 's|[^/]||g' -e 's|/|../|g'` \
+            --define root=`realpath --relative-to="$(pwd)" "$outDir/$fn" | sed -e 's|[^/]||g' -e 's|/|../|g'` \
             --pre_process=common.tt \
             > "$outDirTmp/$fn" <<EOF
 [% WRAPPER layout.tt title="$title" menu='$menu' hideTitle=1 sourceLink='$source' anchors=1 %]

--- a/bootstrapify-docbook.sh
+++ b/bootstrapify-docbook.sh
@@ -18,8 +18,7 @@ mkdir -p "$outDirTmp"
         true
     elif [[ "$fn" =~ .html$ ]]; then
         xsltproc --nonet bootstrapify-docbook.xsl "$inDir/$fn" > "$outDirTmp/$fn.in"
-        touch "$outDir/$fn"
-        root=$(realpath --relative-to="$(pwd)" "$outDir/$fn" | sed -e 's|[^/]||g' -e 's|/|../|g')
+        root=$(realpath --relative-to="$(pwd)" "$outDirTmp/$fn" | sed -e 's|[^/]||g' -e 's|/|../|g')
         tpage --pre_chomp --post_chomp \
             --define root="${root}" \
             --pre_process=common.tt \

--- a/bootstrapify-docbook.sh
+++ b/bootstrapify-docbook.sh
@@ -18,8 +18,10 @@ mkdir -p "$outDirTmp"
         true
     elif [[ "$fn" =~ .html$ ]]; then
         xsltproc --nonet bootstrapify-docbook.xsl "$inDir/$fn" > "$outDirTmp/$fn.in"
+        touch "$outDir/$fn"
+        root=$(realpath --relative-to="$(pwd)" "$outDir/$fn" | sed -e 's|[^/]||g' -e 's|/|../|g')
         tpage --pre_chomp --post_chomp \
-            --define root=`realpath --relative-to="$(pwd)" "$outDir/$fn" | sed -e 's|[^/]||g' -e 's|/|../|g'` \
+            --define root="${root}" \
             --pre_process=common.tt \
             > "$outDirTmp/$fn" <<EOF
 [% WRAPPER layout.tt title="$title" menu='$menu' hideTitle=1 sourceLink='$source' anchors=1 %]

--- a/bootstrapify-docbook.xsl
+++ b/bootstrapify-docbook.xsl
@@ -57,6 +57,35 @@
     <div class="docbook">
       <xsl:apply-templates />
     </div>
+    <xsl:if test="//x:link/@rel">
+      <ul class="pager">
+        <xsl:if test="@class='book'">
+          <xsl:attribute name="class">hidden</xsl:attribute>
+        </xsl:if>
+        <xsl:if test="@class!='book'">
+          <xsl:attribute name="class">pager</xsl:attribute>
+        </xsl:if>
+        <xsl:if test="//x:link[@rel='prev']">
+          <li class="previous">
+            <a accesskey="p"><xsl:attribute name="href"><xsl:value-of select="//x:link[@rel='prev']/@href"/></xsl:attribute>
+            ← <xsl:value-of select="//x:link[@rel='prev']/@title" /></a>
+          </li>
+        </xsl:if>
+        <xsl:if test="//x:link[@rel='up']">
+          <li class="up">
+            <a accesskey="u"><xsl:attribute name="href"><xsl:value-of select="//x:link[@rel='up']/@href"/></xsl:attribute>
+            ↑ <xsl:value-of select="//x:link[@rel='up']/@title" /></a>
+          </li>
+        </xsl:if>
+        <xsl:if test="//x:link[@rel='next']">
+          <li class="next">
+            <a accesskey="n"><xsl:attribute name="href"><xsl:value-of select="//x:link[@rel='next']/@href"/></xsl:attribute>
+            <xsl:value-of select="//x:link[@rel='next']/@title" /> →</a>
+          </li>
+        </xsl:if>
+      </ul>
+    </xsl:if>
+
 
   </xsl:template>
 

--- a/common.tt
+++ b/common.tt
@@ -4,6 +4,7 @@
   nixpkgsManual = "/nixpkgs/manual"
   nixosManual = "/nixos/manual"
   nixopsManual = "/nixops/manual"
+  nixPills = "/nixos/nix-pills"
   latestNixMirror = "https://nixos.org/releases/nix/nix-$latestNixVersion"
   latestNixOSBranch = "release-" _ latestNixOSSeries
   ;

--- a/layout.tt
+++ b/layout.tt
@@ -45,8 +45,6 @@
                 Nix
               [% ELSIF menu == 'nixpkgs' %]
                 Nixpkgs
-              [% ELSIF menu == 'nix-pills' %]
-                Nix Pills
               [% ELSIF menu == 'nixops' %]
                 NixOps
               [% ELSIF menu == 'disnix' %]
@@ -61,7 +59,6 @@
             <ul class="dropdown-menu">
               <li><a href="[%root%]">NixOS</a></li>
               <li><a href="[%root%]nix">Nix</a></li>
-              <li><a href="[%root%]nix-pills">Nix Pills</a></li>
               <li><a href="[%root%]nixops">NixOps</a></li>
               <li><a href="[%root%]nixpkgs">Nixpkgs</a></li>
               <li class="divider"></li>

--- a/layout.tt
+++ b/layout.tt
@@ -45,6 +45,8 @@
                 Nix
               [% ELSIF menu == 'nixpkgs' %]
                 Nixpkgs
+              [% ELSIF menu == 'nix-pills' %]
+                Nix Pills
               [% ELSIF menu == 'nixops' %]
                 NixOps
               [% ELSIF menu == 'disnix' %]
@@ -59,6 +61,7 @@
             <ul class="dropdown-menu">
               <li><a href="[%root%]">NixOS</a></li>
               <li><a href="[%root%]nix">Nix</a></li>
+              <li><a href="[%root%]nix-pills">Nix Pills</a></li>
               <li><a href="[%root%]nixops">NixOps</a></li>
               <li><a href="[%root%]nixpkgs">Nixpkgs</a></li>
               <li class="divider"></li>

--- a/nixos/support.tt
+++ b/nixos/support.tt
@@ -46,6 +46,12 @@
 </div>
 
 <div class="row-fluid">
+  <div class="span4">
+    <h2><a href="[%nixPills%]">Nix Pills</a></h2>
+    <p>The <a href="[%nixPills%]">Nix Pills</a> are to convince you to
+    give Nix a try, and to complement the explanations from the more
+  formal documents, in short digestable pieces.</p>
+  </div>
 
   <div class="span4"> <h2><a
     href="https://github.com/NixOS/nixpkgs/issues">Bugs</a></h2> <p>If
@@ -66,6 +72,10 @@
       cloud using <a href="[%root%]nixops">NixOps</a>.</li>
     </ul>
   </div>
+
+</div>
+
+<div class="row-fluid">
 
   <div class="span4">
     <h2>Commercial support</h2>


### PR DESCRIPTION
1.  Correct root path in manuals

Previous behavior added an extra `../` to the path, which works on web
(extra ../'s get removed once it gets to the root) but broke locally.

2.  When there are navigation links in docbook, present the top and bottom links

3. Distribute the Nix Pills on the website

The about 60% of the nix pills have been ported to docbook. You could merge this now, or wait until they're fully ported. Also, of course, if you wish I did this differently, that'd be fine too :)