### PR TITLE
On chapter pages, use the value of the 'Home' link as the title

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ blogs.json: blogs.xml
 
 ifeq ($(UPDATE), 1)
 .PHONY: nixos/amis.nix nixos/azure-blobs.nix nixpkgs-commits.json nixpkgs-commit-stats.json blogs.xml nixpkgs/packages.json.gz nixpkgs/packages-unstable.json.gz nixos/options.json.gz \
-  $(NIXOS_MANUAL_IN) $(NIXOS_MANUAL_OUT) $(NIX_MANUAL_OUT) $(NIXPKGS_MANUAL_IN) $(HYDRA_MANUAL_IN) nixos-release.tt
+  $(NIXOS_MANUAL_IN) $(NIXOS_MANUAL_OUT) $(NIX_MANUAL_OUT) $(NIXPKGS_MANUAL_IN) $(HYDRA_MANUAL_IN) $(NIX_PILLS_MANUAL_IN) nixos-release.tt
 endif
 
 nixpkgs/packages.json.gz:

--- a/bootstrapify-docbook.xsl
+++ b/bootstrapify-docbook.xsl
@@ -21,7 +21,7 @@
         <h2><xsl:apply-templates select="//x:div[@class='book']/x:div[@class='titlepage']//x:h2/node()"/></h2>
       </xsl:if>
       <xsl:if test="@class!='book'">
-        <h1>NixOS Manual</h1>
+        <h1><xsl:value-of select="//x:link[@rel='home']/@title"/></h1>
       </xsl:if>
     </div>
 


### PR DESCRIPTION
This fixes https://nixos.org/nixos/nix-pills/why-you-should-give-it-a-try.html's header being "NixOS Manual"