### PR TITLE
Add link to Matrix room

### DIFF
--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -82,6 +82,11 @@ href="irc://irc.freenode.net/#nixos"><tt>#nixos</tt> channel</a> on <a
 href="https://freenode.net/"><tt>irc.freenode.net</tt></a>.  This
 channel is <a href="https://nixos.org/irc/logs/">logged</a>.</p>
 
+<h3>Matrix room</h3>
+
+<p>The NixOS community also hang out in the new shiny <a
+href="https://riot.im/app/#/room/#nix:matrix.org"><tt>Matrix room</tt></a>.
+
 <h3>Blogs</h3>
 
 <p><a href="https://planet.nixos.org/">Planet</a> aggregates blog posts written


### PR DESCRIPTION
* You can rephrase as you please.

* Since Matrix room is alive, list it on Community page.

* This contact can also be added to Support page, but that is up to main developers.