### PR TITLE
Display pager buttons before and after content

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -12,6 +12,8 @@
 
 <div id='results-wrapper' class='hide'>
 
+[% INCLUDE renderPager %]
+
 <table class='table table-hover' id='search-results'>
   <thead>
     <tr>

--- a/nixos/packages.tt
+++ b/nixos/packages.tt
@@ -12,6 +12,8 @@
 
 <div id="results-wrapper" class="hide">
 
+[% INCLUDE renderPager %]
+
 <table class="table table-hover" id="search-results">
   <thead>
     <tr>


### PR DESCRIPTION
In the current page the buttons are displayed at the bottom.
If the alignment of the table above changes the buttons move up and down between pages requiring constant aiming when browsing the result list.