### PR TITLE
fix previous inconsistent edit

### DIFF
--- a/nixops/index.tt
+++ b/nixops/index.tt
@@ -47,7 +47,7 @@ running on your desktop). You can then run:</p>
 <span class="command">nixops deploy -d simple</span>
 </pre>
 
-<p>This will create the EC2 instances, and then build, upload and
+<p>This will create the virtual machines, then build and
 activate the NixOS configurations you specified. To change something
 to the configuration, you just edit the specification and run
 <tt>nixops deploy</tt> again.</p>


### PR DESCRIPTION
The first example originally used Amazon EC2 instances (commit 1d0fe27a314544ec49e75ce268d418a9df2fa01a), but when it was changed to VirtualBox (commit 315405748c68063fa8fc154edc87f9d6f321214c), this sentence continued to reference EC2.