### PR TITLE
Add `nix-shell --run make` artefacts to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,31 @@
 *.html
 *.xhtml
 
+/hydra/manual/
+/hydra/manual-raw
+
+/nix/install
+
 /nixos/amis.nix
 /nixos/amis.json
-
 /nixos/azure-blobs.nix
 /nixos/azure-blobs.json
+/nixos/manual/
+/nixos/manual-raw
+/nixos/nix-pills/
+/nixos/nix-pills-raw
+/nixos/options.json.gz
+/nixos/screenshots/nixos-*-small.png
 
-/nixpkgs-commits.json
-/nixpkgs-commit-stats.json
+/nixpkgs/manual/
+/nixpkgs/manual-raw
+/nixpkgs/packages-unstable.json.gz
+/nixpkgs/packages.json.gz
+
 /blogs.json
 /blogs.xml
-
 /favicon.png
+/news-rss.xml
+/nixos-release.tt
+/nixpkgs-commits.json
+/nixpkgs-commit-stats.json


### PR DESCRIPTION
The goal of this PR is to complete the `.gitignore` file w.r.t. the files created by `nix-shell --run make`.