### PR TITLE
Add shackspace/Stuttgart meetup

### DIFF
--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -96,6 +96,7 @@ also contains useful resources.</p>
 <li><a href="http://www.meetup.com/Berlin-NixOS-Meetup/">Berlin NixOS Meetup</a></li>
 <li><a href="https://www.meetup.com/NixOS-London/">London NixOS Meetup</a></li>
 <li><a href="http://www.meetup.com/Munich-NixOS-Meetup/">Munich NixOS Meetup</a></li>
+<li><a href="https://blog.shackspace.de/?p=5829">Stuttgart NixOS Meetup</a></li>
 </ul>
 
 <p>America:</p>


### PR DESCRIPTION
This patch adds the first Stuttgart nixos meetup which will take place in the Stuttgart hackerspace (shackspace.de).