### PR TITLE
Add direct link to Manual for NixOS

### DIFF
--- a/layout.tt
+++ b/layout.tt
@@ -77,6 +77,7 @@
                 <li><a href="[%root%]nixos/options.html">Options</a></li>
                 <li><a href="[%root%]nixos/community.html">Community</a></li>
                 <li><a href="[%root%]nixos/security.html">Security</a></li>
+                <li><a href="[%root%]nixos/manual">Manual</a></li>
               </ul>
               <ul class="nav pull-right">
                 <!--


### PR DESCRIPTION
I know that it is linked under the `Community` page, but all the others like `nix`, `nixpkgs` etc all have a direct link to the Manual on their site.

I missed this direct link on the `NixOS` often enough now that I think it would be worth it to add it.

Thoughts?