### PR TITLE
Splits the navigation in two navbars...

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -380,6 +380,17 @@ div.docbook div.toc dd {
     min-height: 30px
 }
 
+/**
+ * Fixes searchbar on larger mobile responsive breakpoints.
+ */
+@media (max-width: 979px) {
+	.navbar.navbar-primary .search-query {
+		box-sizing: border-box;
+		display: block;
+		width: 100%;
+		height: 30px;
+	}
+}
 
 /**
  * Fixes logo metrics on desktop.

--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -1,7 +1,7 @@
 /* Account for the top navbar. */
 
 body {
-    padding-top: 50px;
+    padding-top: 70px;
 }
 
 @media (max-width: 979px) {
@@ -352,4 +352,67 @@ div.docbook div.toc dd {
     max-width: 196px;
     text-align: center;
   }
+}
+
+/**
+ * Main navbar uses "brand" font styles.
+ */
+.nav.nav-main {
+    font-size: 20px;
+    font-weight: 200;
+}
+
+/**
+ * Secondary navbar is under the main navbar.
+ */
+.navbar-fixed-top.navbar-secondary {
+    top: 40px;
+}
+
+/**
+ * Secondary navbar is smaller.
+ */
+.navbar-secondary.navbar .nav>li>a {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+.navbar-secondary .navbar-inner {
+    min-height: 30px
+}
+
+
+/**
+ * Fixes logo metrics on desktop.
+ */
+@media (min-width: 980px) {
+    .navbar-primary .nav.nav-main {
+        margin-right: 0;
+    }
+    .navbar-primary .nav.nav-main .dropdown-brand a {
+        padding-left: 10px;
+        padding-right: 5px;
+    }
+}
+
+
+/**
+ * Fixes secondary nav for mobile.
+ */
+@media (max-width: 979px) {
+    .navbar-fixed-top {
+        margin-bottom: 0px;
+    }
+    .navbar-primary .navbar-inner {
+        position: relative;
+        z-index: 5;
+    }
+    .navbar-secondary .navbar-inner {
+        position: relative;
+        min-height: 0;
+        margin-top: -15px;
+        z-index: 3;
+    }
+    .navbar-secondary .nav {
+        margin-top: 15px;
+    }
 }

--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -381,6 +381,24 @@ div.docbook div.toc dd {
 }
 
 /**
+ * Makes a divider
+ */
+@media (min-width: 980px) {
+	.nav.nav-main .divider {
+		border-left: 1px solid #dddddd;
+		border-right: 1px solid #ffffff;
+		margin-right: -1px;
+		min-height: 40px;
+	}
+}
+@media (max-width: 979px) {
+	.nav.nav-main .divider {
+		border-top: 1px solid #dddddd;
+		border-bottom: 1px solid #ffffff;
+	}
+}
+
+/**
  * Fixes searchbar on larger mobile responsive breakpoints.
  */
 @media (max-width: 979px) {

--- a/layout.tt
+++ b/layout.tt
@@ -30,7 +30,7 @@
 
   <body>
 
-    <div class="navbar navbar-fixed-top">
+    <div class="navbar navbar-fixed-top navbar-primary">
       <div class="navbar-inner">
         <div class="container">
           <button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
@@ -38,35 +38,72 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <li class="dropdown brand">
-            <a class="dropdown-toggle" href="#" data-toggle="dropdown">
-              <img src="[% root %]logo/nix-wiki.png" alt="NixOS" class="logo" />
-              [% IF menu == 'nix' %]
-                Nix
-              [% ELSIF menu == 'nixpkgs' %]
-                Nixpkgs
-              [% ELSIF menu == 'nixops' %]
-                NixOps
-              [% ELSIF menu == 'disnix' %]
-                Disnix
-              [% ELSIF menu == 'hydra' %]
-                Hydra
-              [% ELSE %]
-                NixOS
-              [% END %]
-              <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-              <li><a href="[%root%]">NixOS</a></li>
-              <li><a href="[%root%]nix">Nix</a></li>
-              <li><a href="[%root%]nixops">NixOps</a></li>
-              <li><a href="[%root%]nixpkgs">Nixpkgs</a></li>
-              <li class="divider"></li>
-              <li><a href="[%root%]hydra">Hydra</a></li>
-              <li><a href="[%root%]disnix">Disnix</a></li>
+            <ul class="nav pull-left nav-main">
+                <li class="dropdown-brand visible-desktop">
+                  <a href="[%root%]">
+                    <img src="[% root %]logo/nix-wiki.png" alt="NixOS" class="logo" />
+                  </a>
+                </li>
+                <li class="dropdown-brand hidden-desktop">
+                  [% SWITCH menu %]
+                  [%   CASE 'nix' %]
+                    <a href="[%root%]nix">
+                      <img src="[% root %]logo/nix-wiki.png" alt="Nix" class="logo" />
+                      <span>Nix</span>
+                    </a>
+                  [%   CASE 'nixops' %]
+                    <a href="[%root%]nixops">
+                      <img src="[% root %]logo/nix-wiki.png" alt="Nix" class="logo" />
+                      <span>NixOps</span>
+                    </a>
+                  [%   CASE 'nixpkgs' %]
+                    <a href="[%root%]nixpkgs">
+                      <img src="[% root %]logo/nix-wiki.png" alt="Nix" class="logo" />
+                      <span>Nixpkgs</span>
+                    </a>
+                  [%   CASE 'hydra' %]
+                    <a href="[%root%]hydra">
+                      <img src="[% root %]logo/nix-wiki.png" alt="Nix" class="logo" />
+                      <span>Hydra</span>
+                    </a>
+                  [%   CASE 'disnix' %]
+                    <a href="[%root%]disnix">
+                      <img src="[% root %]logo/nix-wiki.png" alt="Nix" class="logo" />
+                      <span>Disnix</span>
+                    </a>
+                  [%   CASE %]
+                    <a href="[%root%]">
+                      <img src="[% root %]logo/nix-wiki.png" alt="NixOS" class="logo" />
+                      <span>NixOS</span>
+                    </a>
+                  [% END %]
+                </li>
             </ul>
-          </li>
+          <div class="nav-collapse collapse">
+            <ul class="nav pull-left nav-main">
+              <li class="[% IF menu == 'nixos'   %] active[% END %]"><a href="[%root%]">NixOS</a></li>
+              <li class="[% IF menu == 'nix'     %] active[% END %]"><a href="[%root%]nix">Nix</a></li>
+              <li class="[% IF menu == 'nixops'  %] active[% END %]"><a href="[%root%]nixops">NixOps</a></li>
+              <li class="[% IF menu == 'nixpkgs' %] active[% END %]"><a href="[%root%]nixpkgs">Nixpkgs</a></li>
+              <li class="divider"></li>
+              <li class="[% IF menu == 'hydra'   %] active[% END %]"><a href="[%root%]hydra">Hydra</a></li>
+              <li class="[% IF menu == 'disnix'  %] active[% END %]"><a href="[%root%]disnix">Disnix</a></li>
+            </ul>
 
+            <ul class="nav pull-right">
+              <form class="navbar-search" method="get" action="https://www.google.com/search">
+                <input name="q" type="text" class="search-query span2" placeholder="Search nixos.org"/>
+                <input name="sitesearch" type="hidden" value="nixos.org"/>
+              </form>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="navbar navbar-fixed-top navbar-secondary">
+      <div class="navbar-inner">
+        <div class="container">
           <div class="nav-collapse collapse">
             [% IF menu == 'nixos' %]
               <ul class="nav pull-left">
@@ -79,10 +116,8 @@
                 <li><a href="[%root%]nixos/security.html">Security</a></li>
               </ul>
               <ul class="nav pull-right">
-                <!--
                 <li><a href="https://github.com/NixOS/nixpkgs"><i class="fa fa-github"></i></a></li>
                 <li><a href="https://twitter.com/nixos_org"><i class="fa fa-twitter"></i></a></li>
-                -->
             [% ELSIF menu == 'nix' %]
               <ul class="nav pull-left">
                 <li><a href="[%root%]nix/about.html">About</a></li>
@@ -127,11 +162,6 @@
             [% ELSE %]
               <ul class="nav pull-right">
             [% END %]
-
-              <form class="navbar-search" method="get" action="https://www.google.com/search">
-                <input name="q" type="text" class="search-query span2" placeholder="Search nixos.org"/>
-                <input name="sitesearch" type="hidden" value="nixos.org"/>
-              </form>
             </ul>
           </div>
         </div>

--- a/layout.tt
+++ b/layout.tt
@@ -109,6 +109,7 @@
               <ul class="nav pull-left">
                 <li><a href="[%root%]nixos/about.html">About</a></li>
                 <li><a href="[%root%]nixos/download.html">Download</a></li>
+                <li><a href="[%root%]nixos/manual/">Manual</a></li>
                 <li><a href="[%root%]nixos/support.html">Support</a></li>
                 <li><a href="[%root%]nixos/packages.html">Packages</a></li>
                 <li><a href="[%root%]nixos/options.html">Options</a></li>


### PR DESCRIPTION
### Description of the changes

 * Makes the different projects more obvious.
 * Marks a clearer hierarchy in the website.

In addition, since the DOM had to be manipulated, and we
have a bit more space:

 * Re-adds github and twitter links for nixos project.

The dropdown for the projects is, as a side-effect from manipulating
the DOM, now gone from the mobile view. It is now a flat list of
projects, followed by the page list of that specific section. This
may help with issues like #106.

Furthermore, with the added room, a direct link to the manual has been added to the NixOS website, like #134 and #188 proposes.

* * *

### Motivation for the changes

This is to make the list of projects more approachable at a glance, and to make navigation more explicit between projects.

Though, another reason is that the horizontal real-estate was becoming a bit scarce, since the project name and the search box were present on the same row than the page list for the project. With this change, it is possible to add direct links to resources as needed.

* * *

### Expectations

 * Push back from needing a bit more vertical real-estate on the website.

* * *

### Screenshots

![20180304200611](https://user-images.githubusercontent.com/132835/36953336-e0276d12-1fe7-11e8-88d3-4e5a32e54189.png)

![20180304200653](https://user-images.githubusercontent.com/132835/36953338-e678ffb4-1fe7-11e8-95e1-e2dd3564df80.png)
