### PR TITLE
Centers/Aligns `get *` buttons with the snowflake.

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -343,3 +343,13 @@ div.docbook div.toc dd {
 .license li:last-child:after {
     content: "";
 }
+
+/* Centers the `get` button with the image.
+ * 196px is the width of the image.
+ */
+@media (min-width: 980px) {
+  .get-button {
+    max-width: 196px;
+    text-align: center;
+  }
+}

--- a/index.tt
+++ b/index.tt
@@ -17,9 +17,11 @@
   declarative, makes upgrading systems reliable, and has <a
   href="[%root%]nixos/about.html">many other advantages</a>.</p>
 
+  <div class="get-nixos get-button">
   <a class="btn btn-large btn-success"
   href="[%root%]nixos/download.html"><i class="fa
   fa-cloud-download"></i> Get NixOS</a>
+  </div>
 </div>
 
 <hr />

--- a/nix/index.tt
+++ b/nix/index.tt
@@ -19,6 +19,7 @@
   multi-user package management and easy setup of build
   environments. <a href="[%root%]nix/about.html">Read more…</a></p>
 
+  <div class="get-nix get-button">
   [% WRAPPER makePopover title="<i class='fa fa-cloud-download'></i> Get Nix" %]
 
     <p>On Linux and macOS, the <strong>easiest way to install
@@ -38,6 +39,7 @@
     href="[%root%]nix/download.html">available</a>.</p>
 
   [% END %]
+  </div>
 
 </div>
 


### PR DESCRIPTION
This fixes #67.

* * *

The fix is only applied on "non-mobile" responsive views, as it otherwise adds a *weird margin* to the button, as the button is further from the logo on those resolutions.

An alternative look (e.g. full width) could be defined for the narrower responsive resolutions if desired.

* * *

### Before

![20180304205526](https://user-images.githubusercontent.com/132835/36954206-74813f1e-1fee-11e8-8eca-90c88cfb5978.png)

![20180304205543](https://user-images.githubusercontent.com/132835/36954210-78d0f46a-1fee-11e8-97f3-ba34ad844fa5.png)

### After

![20180304205534](https://user-images.githubusercontent.com/132835/36954209-76f3e1f2-1fee-11e8-95b9-45ea1b017bc0.png)

![20180304205552](https://user-images.githubusercontent.com/132835/36954212-7a2e5e10-1fee-11e8-9dc3-0949056d8b15.png)
