### PR TITLE
Fixes xml issues in description field for options.html

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -282,6 +282,14 @@ div.search-details td.nix {
     font-family: monospace;
 }
 
+#search-results .description.docbook p > .docbook-important {
+	margin-top: 0.5rem;
+}
+
+#search-results .description.docbook .docbook-important {
+	border-left: #F89406 solid 0.3rem;
+	padding-left: 0.5rem;
+}
 
 /* Manual. */
 

--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -295,6 +295,14 @@ function showOption() {
     $($("<code></code>").html(inner)).replaceAll(el);
   });
 
+  // Fixes manpage references.
+  $(x).find("citerefentry manvolnum").each(function (i, el) {
+	var el = $(el).parent();
+	var title = el.children("refentrytitle")[0].innerHTML;
+	var volnum = el.children("manvolnum")[0].innerHTML;
+    $($("<tt class='man_page'></tt>").html(title + "(" + volnum + ")")).replaceAll(el);
+  });
+
   $('.description', details).empty().append($(x).find("para").contents());
 
   if ('default' in opt)

--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -270,8 +270,20 @@ function showOption() {
 
   var details = $('#details-template').clone().removeAttr('id').show();
 
+  // Parses the XML fragment
   var x = $.parseXML('<xml xmlns:xlink="http://www.w3.org/1999/xlink"><para>' + opt.description + '</para></xml>');
-  $('.description', details).empty().append($(x).text());
+
+  // For each xlink, replace with equivalent `<a>`.
+  $(x).find("link").each(function (i, el) {
+    var link = $(el).attr("xlink:href");
+    var inner = el.innerHTML;
+    if (inner === "" || !inner) {
+      inner = link;
+    }
+    $($("<a></a>").html(inner).attr("href", link)).replaceAll(el);
+  });
+
+  $('.description', details).empty().append($(x).find("para").contents());
 
   if ('default' in opt)
     $('.default', details).empty().addClass('pre').text(ppNix('', opt.default));

--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -283,6 +283,12 @@ function showOption() {
     $($("<a></a>").html(inner).attr("href", link)).replaceAll(el);
   });
 
+  // For each [filename], replace with equivalent `<tt>`.
+  $(x).find("filename").each(function (i, el) {
+    var inner = el.innerHTML;
+    $($("<tt></tt>").html(inner)).replaceAll(el);
+  });
+
   // For each [option, literal], replace with equivalent `<code>`.
   $(x).find("option, literal").each(function (i, el) {
     var inner = el.innerHTML;

--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -303,7 +303,23 @@ function showOption() {
     $($("<tt class='man_page'></tt>").html(title + "(" + volnum + ")")).replaceAll(el);
   });
 
-  $('.description', details).empty().append($(x).find("para").contents());
+  // Since `<para>` can be inside a `<para>`, we have to do this ugly loop.
+  // Well, unless someone else has something more elegant.
+  var paras = []
+  while ((paras = $(x).find("para")).length > 0) {
+    paras.each(function (i, el) {
+      var inner = el.innerHTML;
+      $($("<p></p>").html(inner)).replaceAll(el);
+    });
+  }
+
+  // For each [option, literal], replace with equivalent `<code>`.
+  $(x).find("important").each(function (i, el) {
+    var inner = el.innerHTML;
+    $($("<div class='docbook-important'></div>").html(inner)).replaceAll(el);
+  });
+
+  $('.description', details).empty().append($(x).contents());
 
   if ('default' in opt)
     $('.default', details).empty().addClass('pre').text(ppNix('', opt.default));

--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -283,6 +283,12 @@ function showOption() {
     $($("<a></a>").html(inner).attr("href", link)).replaceAll(el);
   });
 
+  // For each [option, literal], replace with equivalent `<code>`.
+  $(x).find("option, literal").each(function (i, el) {
+    var inner = el.innerHTML;
+    $($("<code></code>").html(inner)).replaceAll(el);
+  });
+
   $('.description', details).empty().append($(x).find("para").contents());
 
   if ('default' in opt)


### PR DESCRIPTION
### Fixes links in description fields

To verify:

 * Search using the <input> for `<link`.
 * An example option with link: `boot.initrd.luks.mitigateDMAAttacks`

I say this finishes fixing #89 assuming that [the commit that fixed it *partially*](https://github.com/NixOS/nixos-homepage/pull/97) has this description:

> links are still not rendered as HTML links

This now renders the links.

![20180304213334](https://user-images.githubusercontent.com/132835/36955004-b889666e-1ff3-11e8-9f1d-f1e01a7be303.png)


### Styles literal and options

To verify:

  * `boot.extraTTYs` has both.

![20180304213114](https://user-images.githubusercontent.com/132835/36954957-64a868ba-1ff3-11e8-8dcf-5bc4df60f968.png)


* * *

If there are extra tags I missed, don't hesitate to open an issue and tag me in it.