### PR TITLE
options, packages: fetch a compressed version only on nixos.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,3 @@ build it:
     $ git clone git@github.com:NixOS/nixos-homepage.git
     $ cd nixos-homepage
     $ nix-shell --command make
-
-To make the 'packages' page work via file:///, you must unzip the
-packages.json and start your browser with CORS disabled for local files:
-
-    $ gzip -d nixpkgs/packages.json.gz
-    $ mv nixpkgs/packages.json nixpkgs/packages.json.gz
-    $ chromium --allow-file-access-from-files

--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@ build it:
 
     $ git clone git@github.com:NixOS/nixos-homepage.git
     $ cd nixos-homepage
-    $ nix-shell --command make
+    $ nix-shell
+    [nix-shell]$ make
+    [nix-shell]$ python2 -m SimpleHTTPServer 8000
+
+then open http://127.0.0.1:8000/index.html

--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -298,7 +298,7 @@ function showOption() {
 };
 
 $.ajax({
-  url: '[%root%]nixos/options.json.gz',
+  url: ((document.domain == 'nixos.org') ? '[%root%]nixos/options.json.gz' : '[%root%]nixos/options.json'),
   type: 'GET',
   dataType: 'json',
   error: function(a, b, c) { alert('Failed to get option data.'); },

--- a/nixos/packages.tt
+++ b/nixos/packages.tt
@@ -266,7 +266,7 @@ function showPackage() {
 };
 
 $.ajax({
-  url: "[%root%]nixpkgs/packages.json.gz",
+  url: ((document.domain == 'nixos.org') ? '[%root%]nixpkgs/packages.json.gz' : '[%root%]nixpkgs/packages.json'),
   type: "GET",
   dataType: "json",
   error: function(a, status, error) { alert("Failed to get package data [" + status + "]: " + error); },


### PR DESCRIPTION
Also change the Makefile to produce packages.json, options.json as
well as options.json.gz and packages.json.gz

This makes it quite a bit easier to test the website locally, and you don't even need a server to do it. Just visiting the HTML file in your browser will do the trick.