### PR TITLE
Copy non-standard styles from the generated docs + JS for richer docs

### DIFF
--- a/bootstrapify-docbook.xsl
+++ b/bootstrapify-docbook.xsl
@@ -14,7 +14,8 @@
   </xsl:template>
 
   <xsl:template match="*" mode="top">
-
+    <xsl:apply-templates select="//x:script[@type='text/javascript']"/>
+    <xsl:apply-templates select="//x:link[@rel='stylesheet' and @href!='style.css']"/>
     <div class="page-header">
       <xsl:if test="@class='book'">
         <h1><xsl:apply-templates select="//x:div[@class='book']/x:div[@class='titlepage']//x:h1/node()"/></h1>


### PR DESCRIPTION
I'm working on making the docs a bit nicer. One thing I have done is replaced the .gif's with .svg's: https://github.com/NixOS/nixpkgs/pull/37881 This worked nicely, but because the CSS is completely replaced on deploy to the website, the images break down (see my first comment.)

The simple fix for that is send a PR here adding those six lines to the global CSS, but a more flexible option is allowing some CSS to be carried over from the generated HTML in to the bootstrapified HTML.

I chose _this_ option, though, because a follow-up PR is adding syntax highlighting of our Nix code to the docs. This will also require custom CSS, and a bit of javascript. It seems nice for the `nix-build` version to have the highlighting, so I'm wary of duplicating the logic in both places ... thus this solution.

This PR, combined with my SVG PR, combined with my syntax highlighting branch come together to look like this:

![image](https://user-images.githubusercontent.com/76716/37926644-d499c8c6-3105-11e8-8141-c24e529c59be.png)
