### PR TITLE
Fixes horizontal scrolling originating from `<code>` blocks. (in nixpkgs manual)

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -315,6 +315,7 @@ div.docbook code {
     background-color: inherit;
     color: inherit;
     font-size: 100%;
+    white-space: normal;
 }
 
 div.docbook div.toc {


### PR DESCRIPTION
See: https://twitter.com/kumbunterland/status/982638331757506567

The `<code>` blocks are normally expected to have a `white-space`
property of `normal`, at least I assume docbook would expect the
default. Bootstrap (2.3) changes it to nowrap, which isn't helpful for
an inline type element.

* * *

This is replaced only for the `docbook` pages. If there is somewhere else `<code>` elements are used and exhibit the same issue, the rule can be expanded.

* * *

##### Before

![20180407143659](https://user-images.githubusercontent.com/132835/38458913-3a62312e-3a71-11e8-8286-e7e2f00bb578.png)

##### After

![20180407143707](https://user-images.githubusercontent.com/132835/38458916-3e34e72e-3a71-11e8-9c06-11845154bda2.png)


* * *

cc: @grahamc (in case graham's trying to fix it)