### PR TITLE
doc: overrides `hljs` overflow rules for better linking.

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -326,6 +326,10 @@ div.docbook div.toc dd {
     margin-left: 2em;
 }
 
+div.docbook pre.hljs {
+    overflow-x: visible;
+}
+
 .license ul {
     margin-left: 0px;
 }


### PR DESCRIPTION
This sets the `pre`'s `overflow-x` to `visible`, which is the initial value, which is overridden by the new `hljs` dependency. Anchor links inside boxes with an `overflow` or `position` set cannot account for the top navbar's height in the first 80px of an element, this is a limitation of how CSS works. This could be worked-around using JavaScript (I think), but the previous behaviour did not cause any issues AFAIK.

###### Before

After clicking on `(1)`

![20180407162018](https://user-images.githubusercontent.com/132835/38460058-815255f0-3a80-11e8-87b0-39105c5658ef.png)

###### After

After clicking on `(1)`

![20180407162002](https://user-images.githubusercontent.com/132835/38460055-77358204-3a80-11e8-9023-7dae418e2eb0.png)
