### PR TITLE
Allow passing arguments to the Nix installer

### DIFF
--- a/nix/install.in
+++ b/nix/install.in
@@ -62,6 +62,6 @@ mkdir -p "$unpack"
 script=$(echo "$unpack"/*/install)
 
 [ -e "$script" ] || oops "installation script is missing from the binary tarball!"
-"$script"
+"$script" "$@"
 
 } # End of wrapping


### PR DESCRIPTION
This PR will allow users to pass arguments to he installer and have them be passed to the actual installer.

Example:

```
$ cat test.sh 
#!/bin/sh
{
echo "$@"
}

$ cat test.sh | sh -s hi eelco
hi eelco
```

Then, the interior installer can learn `--no-daemon` and `--daemon`, forcing on or off the switch to the daemon installer, overriding any detection done. The nix 2.0-maintenance can then receive the patches  but _default_ to single-user on Linux, but users can override it.

I'm hoping that by merging this PR and a subsequent PR to Nix we can bring back the multi-user installer for Linux 2.0. 