### PR TITLE
nixos/packages: fix maintainer listing (they are no longer strings)

### DIFF
--- a/nixos/packages.tt
+++ b/nixos/packages.tt
@@ -252,7 +252,13 @@ function showPackage() {
   var maintainers = info["meta"]["maintainers"];
   if (Array.isArray(maintainers) && maintainers.length > 0)
     // FIXME: check whether elements are strings.
-    $(".maintainers", details).empty().text(maintainers.join(", "));
+    $(".maintainers", details)
+      .empty()
+      .text(
+        $.map(maintainers, function(element) {
+          return typeof element === 'object' ? element.name + ' <' + element.email + '>' : element;
+        })
+      .join(", "));
 
   var longDescription = info["meta"]["longDescription"];
   if (typeof longDescription == "string")


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/commit/aa47bac04f06aeea993dc2e2cc6649fde4f31ed7#diff-94cbd9d7bdc2427d0efb29692838d2c5 these have been showing up as `[object Object]` in the package listing, which is the result of casting an object without a toString method to a string in JavaScript.

![image](https://user-images.githubusercontent.com/3422442/39350989-068a473c-4a3f-11e8-9ec7-98358fca86a6.png)

This change tries to format them in the same way that they used to be displayed, like `Maintainer Name <name@example.com>`.

Ref: https://github.com/NixOS/nixos-homepage/issues/208