### PR TITLE
add discourse to community page

### DIFF
--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -69,6 +69,18 @@ GitHub</a>. NixOS lives in the <a
 href="https://github.com/NixOS/nixpkgs/tree/master/nixos">nixos</a>
 subdirectory of the Nixpkgs repository.</p>
 
+<h3>Discourse</h3>
+
+<p><a href="https://discourse.nixos.org">discourse.nixos.org</a> hosts
+a community of Nix developers and users, providing resources to help
+you:</p>
+
+<ul>
+<li>find answers to your Nix/Nixpkgs/NixOS/NixOps questions</li>
+<li>discuss current and future directions of the project</li>
+<li>evangelise and promote Nix in your community</li>
+</ul>
+
 <h3>Mailing list</h3>
 
 <p>NixOS development is coordinated on the <a


### PR DESCRIPTION
This adds our Discourse to the community page. I copied the description of it from https://discourse.nixos.org/t/welcome-to-discourse/8