### PR TITLE
add coqPackages, idrisPackages, nodePackages, quicklispPackages to package list

### DIFF
--- a/discover-more-packages-config.nix
+++ b/discover-more-packages-config.nix
@@ -4,12 +4,16 @@
 
 {
 
-  packageOverrides = super: {
-
-    haskellPackages = super.recurseIntoAttrs super.haskellPackages;
-
-    rPackages = super.recurseIntoAttrs super.rPackages;
-
-  };
-
+  packageOverrides = super:
+    builtins.foldl'
+     (s: packageSet: s //
+       { "${packageSet}" = super.recurseIntoAttrs super."${packageSet}"; })
+     {} [
+          "coqPackages"
+          "haskellPackages"
+          "idrisPackages"
+          "nodePackages"
+          "quicklispPackages"
+          "rPackages"
+        ];
 }


### PR DESCRIPTION
I looked over all the package sets at the top level to find ones not in the current package listing; this change adds the coq, idris, node, and quicklisp sets. The uncompressed archive got 1 MB bigger from this change, and the compressed one got less than 100 KB bigger.