### PR TITLE
Removes useless escapes from `ppNix` in options page.

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -210,7 +210,7 @@ function ppNix(indent, v) {
     // their content as it cannot be serialize properly. So if we detect such
     // example, escape characters and return the text without pretty-printing.
     if (v._type == "literalExample") {
-      v = ((v.text || '') + '').replace('<', '&lt;').replace('>', '&gt;');
+      v = ((v.text || '') + '');
       return v;
     }
 
@@ -243,7 +243,6 @@ function ppNix(indent, v) {
   }
 
   if (typeof v == "string") {
-    v = v.replace('<', '&lt;').replace('>', '&gt;');
     if (v.indexOf('"') == -1 && v.indexOf('\n') == -1) {
       if (/^pkgs\./.test(v))
         return '' + v;


### PR DESCRIPTION
This is safe since all calls to `ppNix` are made using `.text()`.

 * https://github.com/NixOS/nixos-homepage/blob/f74049df65db247ce156022155a966c272ffb96c/nixos/options.tt#L324-L328

And *anyway* the previous escapes were done only one time, making it
trivial to bypass

```
> "<<<<<".replace("<", "&gt;")
→ "&gt;<<<<"
```

This has further been manually verified (with an hand-modified options.json) to
not cause opportunities for HTML injection.

![image](https://user-images.githubusercontent.com/132835/42138650-c5b02b62-7d4e-11e8-9384-af54293a52b3.png)

![image](https://user-images.githubusercontent.com/132835/42138652-c8413a4c-7d4e-11e8-9bf4-9b6c5542cb45.png)
