### PR TITLE
Fixes build when pointing to a nixpkgs checkout.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ endif
 
 nixpkgs/packages.json: discover-more-packages-config.nix
 	nixpkgs=$$(nix-instantiate --find-file nixpkgs -I nixpkgs=$(NIXPKGS)); \
-	(echo -n '{ "commit": "' && cat $$nixpkgs/.git-revision && echo -n '","packages":' \
+	(echo -n '{ "commit": "' && (cat $$nixpkgs/.git-revision || printf "unknown") && echo -n '","packages":' \
 	  && nix-env -f '<nixpkgs>' -I nixpkgs=$(NIXPKGS) -qa --json --arg config 'import ./discover-more-packages-config.nix' \
 	  && echo -n '}') \
 	  | sed "s|$$nixpkgs/||g" > $@.tmp
@@ -223,7 +223,7 @@ nixpkgs/packages.json: discover-more-packages-config.nix
 
 nixpkgs/packages-unstable.json: discover-more-packages-config.nix
 	nixpkgs=$$(nix-instantiate --find-file nixpkgs -I nixpkgs=$(NIXPKGS_UNSTABLE)); \
-	(echo -n '{ "commit": "' && cat $$nixpkgs/.git-revision && echo -n '","packages":' \
+	(echo -n '{ "commit": "' && (cat $$nixpkgs/.git-revision || printf "unknown") && echo -n '","packages":' \
 	  && nix-env -f '<nixpkgs>' -I nixpkgs=$(NIXPKGS_UNSTABLE) -qa --json --arg config 'import ./discover-more-packages-config.nix' \
 	  && echo -n '}') \
 	  | sed "s|$$nixpkgs/||g" > $@.tmp


### PR DESCRIPTION
Important when a fix is made in nixpkgs when the fix intends to fix the
website generation.

To test, use something like this:

```diff
diff --git a/Makefile b/Makefile
index efc07d3..91479fd 100644
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NIXOS_SERIES = 18.03
 NIXPKGS = https://nixos.org/channels/nixos-$(NIXOS_SERIES)/nixexprs.tar.xz
-NIXPKGS_UNSTABLE = https://nixos.org/channels/nixos-unstable/nixexprs.tar.xz
+NIXPKGS_UNSTABLE = /Users/samuel/tmp/nixpkgs/nixpkgs

 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))

```

Then `make nixpkgs/packages-unstable.json.gz`.