### PR TITLE
Fixes emoji titles by uppercasing only letters.

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -76,11 +76,15 @@
       [% FOREACH b IN JSON.Escape.json_decode(IO.All.new('blogs.json').all).channel.item.first(5); IF b; %]
         <li>
           <div class="nixos-blog">
-            [% author = b.title.split(':').0.trim;
-               title = b.title.remove('^[^:]*:').trim
+            [%
+              USE title = String(HTML.escape(b.title.remove('^[^:]*:').trim));
+              title = title.replace('^[a-z]', title.copy.truncate(1).upper)
+              author = b.title.split(':').0.trim;
+            %]
+            [%
             %]
             <div class="nixos-blog-title">
-              <a [% HTML.attributes(href => b.link) %]>[% HTML.escape(title.ucfirst) %]</a>
+              <a [% HTML.attributes(href => b.link) %]>[% title %]</a>
             </div>
             <div class="nixos-blog-author-info">
               <span class="nixos-blog-author">[% HTML.escape(author) %]</span>


### PR DESCRIPTION
Template Toolkit doesn't really care about UTF-8, but this ISN'T
template toolit's fault. This was `ucfirst` that was munging the
initial emoji.

* * *

Before this fix:

```
[nix-shell:~/.../nixos/nixos-homepage]$ rm index.html ; make index.html
tpage \
  --pre_chomp --post_chomp \
  --define modifiedAt="`git log -1 --pretty='%ai' index.tt`" \
  --define modifiedBy="`git log -1 --pretty='%an' index.tt`" \
  --define root=`echo index.html | sed -e 's|[^/]||g' -e 's|/|../|g'` \
  --define fileName=index.tt \
  --pre_process=nix-release.tt --pre_process=nixos-release.tt --pre_process=common.tt \
  index.tt > index.html.tmp
xmllint --nonet --noout index.html.tmp
index.html.tmp:290: parser error : Input is not proper UTF-8, indicate encoding !
Bytes: 0x8F 0x83 0xF0 0x9F
             <a href="http://grahamc.com/blog/cache-nixos-org-now-more-local">П
                                                                               ^
make: *** [Makefile:132: index.html] Error 1

```

After the fix:

```
[nix-shell:~/.../nixos/nixos-homepage]$ rm index.html ; make index.html
tpage \
  --pre_chomp --post_chomp \
  --define modifiedAt="`git log -1 --pretty='%ai' index.tt`" \
  --define modifiedBy="`git log -1 --pretty='%an' index.tt`" \
  --define root=`echo index.html | sed -e 's|[^/]||g' -e 's|/|../|g'` \
  --define fileName=index.tt \
  --pre_process=nix-release.tt --pre_process=nixos-release.tt --pre_process=common.tt \
  index.tt > index.html.tmp
xmllint --nonet --noout index.html.tmp
mv index.html.tmp index.html
```

![image](https://user-images.githubusercontent.com/132835/44181930-93ea9200-a0d2-11e8-8dea-9e154b0e0306.png)

The running individual is present and doesn't trip up the site update process.

* * *

## This fixes the issue where anything that gets "made" (`make`'d) after `index.html` isn't being built.