### PR TITLE
Make it more obvious that nixos options in the search results are clickable

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -99,7 +99,8 @@ function updateTable() {
       .addClass('result')
       .addClass(odd ? 'odd' : 'even')
       .click(showOption)
-      .append($('<td/>', { class: 'option', text: optName }))
+      .append($('<td/>', { class: 'option' }).append($('<a/>', { text: optName })))
+
     );
     odd = !odd;
   });


### PR DESCRIPTION
While talking to someone that just started looking into NixOS we figured
out that he wasn't aware that those search results were clickable at
all. While we already changed the cursor while hovering the entries you
would not really be hinted into clicking on them.

This is especially relevant for people using keyboard navigation
(vim-style or similar) since those entries wouldn't show up as
clickable.

With this commit I am just wrapping the text in an anchor tag. That is
enough to make them appear like other links on the website. They also
appear as clickable when using keyboard navigation.

# Before

![old](https://user-images.githubusercontent.com/638836/45589688-3b552180-b92a-11e8-9943-8418123aa4a1.png)
---

# After

![new](https://user-images.githubusercontent.com/638836/45589687-37c19a80-b92a-11e8-91eb-64d2f7ca97b2.png)

