### PR TITLE
options: Adds type information to the options list

### DIFF
--- a/nixos/options.tt
+++ b/nixos/options.tt
@@ -43,6 +43,12 @@
       </td>
     </tr>
     <tr>
+      <th>Type:</th>
+      <td>
+      <td class='type'><em>Not given</em></td>
+      </td>
+    </tr>
+    <tr>
       <th>Example value:</th>
       <td>
       <td class='example'><em>Not given</em></td>
@@ -323,6 +329,9 @@ function showOption() {
 
   if ('default' in opt)
     $('.default', details).empty().addClass('pre').text(ppNix('', opt.default));
+
+  if ('type' in opt)
+    $('.type', details).empty().addClass('pre').text(opt.type);
 
   if ('example' in opt)
     $('.example', details).empty().addClass('pre').text(ppNix('', opt.example));


### PR DESCRIPTION
The data was already available!

This uses the (possibly composed) description field from the types.

This was inspired by @ryantm who [was curious about listing the type descriptions on the options page](https://logs.nix.samueldr.com/nixos/2018-10-11#1638655;).

See https://github.com/NixOS/nixpkgs/pull/48251 for better descriptions for `separatedString`.

* * *

## Sneak peek

![image](https://user-images.githubusercontent.com/132835/46843688-fe9e0e00-cda1-11e8-9095-b2c62bbdbab0.png)

![image](https://user-images.githubusercontent.com/132835/46843692-01006800-cda2-11e8-812b-ab1e98e51b96.png)
