### PR TITLE
nixos/packages: display license long name first

### DIFF
--- a/nixos/packages.tt
+++ b/nixos/packages.tt
@@ -167,11 +167,11 @@ function refilter() {
 };
 
 // Try to figure out a human-readable name for a license object.
-// Use the SPDX ID if present; failing that try the long or short names. If all
-// else fails fall back on URL.
+// Use the long name first; failing that try the SPDX ID or short name.
+// If all else fails fall back on URL.
 function licenseName(license) {
-  return license.spdxId
-    || license.fullName
+  return license.fullName
+    || license.spdxId
     || license.shortName
     || license.url
     || "Licence name missing!";


### PR DESCRIPTION
It seems to me that any licenses' long name is the most human-friendly attribute for presentation on a website.  `fullName` is intended to be a text string for human presentation.

Then comes SPDX ids (if defined) which were made to be both [human and machine-readable](https://spdx.org/ids).

```scala
nix-repl> stdenv.lib.licenses.bsl11
{ fullName = "Business Source License 1.1"; shortName = "bsl11"; url = "https://mariadb.com/bsl11"; }

nix-repl> stdenv.lib.licenses.lppl13c
{ fullName = "LaTeX Project Public License v1.3c"; shortName = "lppl13c"; spdxId = "LPPL-1.3c"; url = "http://spdx.org/licenses/LPPL-1.3c.html"; }

nix-repl> stdenv.lib.licenses.cc-by-sa-40
{ fullName = "Creative Commons Attribution Share Alike 4.0"; shortName = "cc-by-sa-40"; spdxId = "CC-BY-SA-4.0"; url = "http://spdx.org/licenses/CC-BY-SA-4.0.html"; }
```

cc @samueldr 