### PR TITLE
refer to current logs on community page

### DIFF
--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -86,7 +86,7 @@ you:</p>
 <p>The NixOS developers hang out on the <a
 href="irc://irc.freenode.net/#nixos"><tt>#nixos</tt> channel</a> on <a
 href="https://freenode.net/"><tt>irc.freenode.net</tt></a>.  This
-channel is <a href="https://nixos.org/irc/logs/">logged</a>.</p>
+channel is <a href="https://logs.nix.samueldr.com/nixos/">logged</a>.</p>
 
 <h3>Blogs</h3>
 


### PR DESCRIPTION
The log archive linked hasn't been updated since 2016. The new one is the one linked in the channel itself: It's up-to-date and searchable.