### PR TITLE
Replaced Cloudfront URLs with NixOS.org URLs

### DIFF
--- a/nixos/download.tt
+++ b/nixos/download.tt
@@ -30,7 +30,7 @@ installer as well as X11, Plasma 5 Desktop and several applications.  It’s a
 <em>live CD</em>, so it allows you to get an impression of NixOS (and
 the Nix package manager) before installing it.</p>
 
-[% prefix = "https://d3g5gsiof5omrk.cloudfront.net/nixos/" _ latestNixOSSeries _ "/nixos-" _ latestNixOSRelease %]
+[% prefix = "https://releases.nixos.org/nixos/" _ latestNixOSSeries _ "/nixos-" _ latestNixOSRelease %]
 
 <ul>
   <li><a href="[%prefix%]/nixos-graphical-[%latestNixOSRelease%]-x86_64-linux.iso">Graphical live CD, 64-bit Intel/AMD</a> (<a href="[%prefix%]/nixos-graphical-[%latestNixOSRelease%]-x86_64-linux.iso.sha256">SHA-256</a>)


### PR DESCRIPTION
In commit 70bcfbb the prefix of the download URLs was changed from

`https://nixos.org/releases/nixos/...`

to

`https://d3g5gsiof5omrk.cloudfront.net/nixos/...`

This doesn't seem ideal since the URL is pointing to a non-NixOS URL. I have
verified that the replacing the Cloudfront URL with `https://releases.nixos.org/nixos/...`
seems to work for all the URLs we care about.

Hence changing the prefix back to NixOS.org's site seems right thing to do.