### PR TITLE
Clarify supported Mac OS X versions

### DIFF
--- a/nixpkgs/index.tt
+++ b/nixpkgs/index.tt
@@ -9,7 +9,7 @@ all packages work on all platforms):</p>
 <ul>
   <li>GNU/Linux on 32-bit (<tt>i686-linux</tt>)</li>
   <li>GNU/Linux on 64-bit x86 (<tt>x86_64-linux</tt>)</li>
-  <li>Mac OS X (<tt>x86_64-darwin</tt>)</li>
+  <li>Mac OS X (<tt>x86_64-darwin</tt>) (Mac OS X v10.10+)</li>
   <li>Beta support for GNU/Linux on ARM's aarch64 (<tt>aarch64-linux</tt>)</li>
 </ul>
 


### PR DESCRIPTION
Message from `nix-2.2.2-x86_64-darwin/install` states `upgrade to 10.10 or higher`.

Also, this comment includes a link to a tag for the last version that supported 10.9: https://github.com/NixOS/nixpkgs/issues/18472#issuecomment-247784839