### PR TITLE
Remove Nix link

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -32,10 +32,10 @@
       <h2>What is NixOS?</h2>
     
       <p>NixOS is a Linux distribution with a unique approach
-      to package and configuration management.  Built on top of the <a
-      href="[%root%]nix">Nix package manager</a>, it is completely
-      declarative, makes upgrading systems reliable, and has <a
-      href="[%root%]nixos/about.html">many other advantages</a>.</p>
+      to package and configuration management. Built on top of the
+      Nix package manager, it is completely declarative, makes
+      upgrading systems reliable, and has
+      <a href="[%root%]nixos/about.html">many other advantages</a>.</p>
     
       <div class="learn-more">
         <a class="btn btn-success" href="[%root%]nixos/">


### PR DESCRIPTION
We have a link to the Nix page already on the left now. So this link is not needed anymore.

This change should make the page less chaotic.

(I havn't tested to build it.)

cc @samueldr