### PR TITLE
index: Uses the nixos menu, as it did beforehand...

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -1,4 +1,4 @@
-[% WRAPPER layout.tt title="NixOS Linux" hideTitle=1 menu='organization' %]
+[% WRAPPER layout.tt title="NixOS Linux" hideTitle=1 menu='nixos' %]
 [% USE JSON.Escape %]
 [% USE IO.All %]
 [% USE HTML %]


### PR DESCRIPTION
Until we have a better story to make it obvious that there are
subsections for the site, and there are different menus for subsection,
restoring the old menu on the index is probably the sage decision.