### PR TITLE
docs: show <command>s as monospaced

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -419,6 +419,10 @@ div.docbook pre.hljs {
     overflow-x: visible;
 }
 
+div.docbook span.command {
+    font-family: Monaco, Menlo, Consolas, "Courier New", monospace; /* from bootstrap*/
+}
+
 .license ul {
     margin-left: 0px;
 }


### PR DESCRIPTION
before & after in the same picture:

![image](https://user-images.githubusercontent.com/76716/63519542-2cbfa480-c4c1-11e9-8b0e-d1b824ada75a.png)

This improves other `<command>`s too. After:

![image](https://user-images.githubusercontent.com/76716/63519580-3d701a80-c4c1-11e9-9069-be80e00bea99.png)

before:

![image](https://user-images.githubusercontent.com/76716/63519632-49f47300-c4c1-11e9-9a42-df416dbe706d.png)


re https://github.com/NixOS/nix/pull/3052