### PR TITLE
Use new link to manual on download page

### DIFF
--- a/nixpkgs/download.tt
+++ b/nixpkgs/download.tt
@@ -36,7 +36,7 @@ continuous build system:</p>
   latest development release of Nixpkgs</a> (<a
   href="https://hydra.nixos.org/job/nixpkgs/trunk/tarball/latest/download-by-type/file/source-dist">source
   tarball</a>, <a
-  href="https://hydra.nixos.org/job/nixpkgs/trunk/tarball/latest/download-by-type/doc/manual">manual</a>, <a href="https://hydra.nixos.org/job/nixpkgs/trunk/unstable#tabs-constituents">status</a>)</li>
+  href="https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/nixpkgs/manual.html">manual</a>, <a href="https://hydra.nixos.org/job/nixpkgs/trunk/unstable#tabs-constituents">status</a>)</li>
 </ul>
 
 </section>


### PR DESCRIPTION
Fixes #80
https://nixos.org/nixpkgs/download.html has a broken link to the unstable manual.