### PR TITLE
packages-explorer: Adds autofocus

### DIFF
--- a/packages-explorer/src/gui/query.js
+++ b/packages-explorer/src/gui/query.js
@@ -12,6 +12,7 @@ const Query = ({query, set_query}) =>
 			defaultValue={query}
 			onChange={(event) => set_query(event.target.value)}
 			onBlur={(event) => set_query(event.target.value, true)}
+			autofocus="autofocus"
 		/>
 	</div>
 ;


### PR DESCRIPTION
Tested the change using `make` then running the python2 http server, as the README states.

The change is rather trivial, and fixes a minor regression that was pointed out by @joepie91.