### PR TITLE
hydra doc: fetching from latest successful job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ $(HYDRA_MANUAL_OUT): $(HYDRA_MANUAL_IN) bootstrapify-docbook.sh bootstrapify-doc
 	ln -sfn manual.html $(HYDRA_MANUAL_OUT)/index.html
 
 $(HYDRA_MANUAL_IN):
-	path=$$(curl -LH 'Accept: application/json' https://hydra.nixos.org/build/41892729 | jq -re '.buildoutputs.out.path') && \
+	path=$$(curl -LH 'Accept: application/json' https://hydra.nixos.org/job/hydra/master/manual/latest | jq -re '.buildoutputs.out.path') && \
 	nix-store -r $$path && \
 	ln -sfn $$path/share/doc/hydra $(HYDRA_MANUAL_IN)
 


### PR DESCRIPTION
The hydra doc has been out of date for a while because it was
pinned to a particular job from 2016. This should keep this part
up-to-date in line with the other parts of the homepage.