### PR TITLE
nixos/support: link to nixpkgs manual

### DIFF
--- a/nixos/support.tt
+++ b/nixos/support.tt
@@ -66,6 +66,10 @@
     <ul>
       <li>The <a href="https://nixos.wiki"><strong>NixOS Wiki</strong></a>
       is an unofficial wiki maintained by the community.</li>
+      <li>The <a href="[%nixpkgsManual%]"><strong>Nixpkgs
+      manual</strong></a> describes how to use the
+      <a href="[%root%]nixpkgs">package collection</a> that NixOS is
+      built on.</li>
       <li>The <a href="[%nixManual%]"><strong>Nix manual</strong></a>
       describes how to use the <a href="[%root%]nix">Nix package
       manager</a>.</li>


### PR DESCRIPTION
There's already a lot of confusion between the three manuals, because
people can't find the things they're looking for in whichever one they
look at (usually the NixOS manual).  This is even worse when they
don't even know about the existence of the other manuals!