### PR TITLE
Rename Support to Learn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default: all
 HTML = index.html news.html \
   nix/index.html nix/about.html nix/download.html \
   nixpkgs/index.html nixpkgs/download.html \
-  nixos/index.html nixos/about.html nixos/download.html nixos/support.html \
+  nixos/index.html nixos/about.html nixos/download.html nixos/learn.html \
   nixos/community.html nixos/packages.html nixos/options.html \
   nixos/security.html nixos/foundation.html \
   nixos/wiki.html \

--- a/disnix/support.tt
+++ b/disnix/support.tt
@@ -8,7 +8,7 @@
   href="irc://irc.freenode.net/#nixos"><tt>#nixos</tt></a> on <a
   href="https://freenode.net/"><tt>irc.freenode.net</tt></a>.</li>
 
-  <li>You can use the <a href="[%root%]nixos/support.html#discourse"><tt>Discourse</tt> forum</a>.</li>
+  <li>You can use the <a href="[%root%]nixos/learn.html#discourse"><tt>Discourse</tt> forum</a>.</li>
 
   <li>You can <strong>report bugs</strong> in the <a
   href="https://github.com/svanderburg/disnix/issues">Disnix issue

--- a/hydra/index.tt
+++ b/hydra/index.tt
@@ -44,7 +44,7 @@ please visit:</p>
 
 <ul>
   <li><a href="https://github.com/NixOS/hydra/issues">github.com/NixOS/hydra/issues</a>: issues, bugs and feature requests for Hydra</li>
-  <li><a href="[%root%]nixos/support.html#discourse"><tt>Discourse</tt> forum</a>: problems with our Hydra instance at <a href="https://hydra.nixos.org/">hydra.nixos.org</a></li>
+  <li><a href="[%root%]nixos/learn.html#discourse"><tt>Discourse</tt> forum</a>: problems with our Hydra instance at <a href="https://hydra.nixos.org/">hydra.nixos.org</a></li>
 </ul>
 
 </section>

--- a/index.tt
+++ b/index.tt
@@ -89,8 +89,8 @@
           </a>
         </li>
         <li>
-          <a href="[%root%]/nixos/support.html">
-            Getting support
+          <a href="[%root%]/nixos/learn.html">
+            Learning resources
             <i class="fa fa-angle-right"></i>
           </a>
         </li>

--- a/layout.tt
+++ b/layout.tt
@@ -76,7 +76,7 @@
               <ul class="nav pull-left">
                 <li><a href="[%root%]nixos/about.html">About</a></li>
                 <li><a href="[%root%]nixos/download.html">Download</a></li>
-                <li><a href="[%root%]nixos/support.html">Support</a></li>
+                <li><a href="[%root%]nixos/learn.html">Learn</a></li>
                 <li><a href="[%root%]nixos/packages.html">Packages</a></li>
                 <li><a href="[%root%]nixos/options.html">Options</a></li>
                 <li><a href="[%root%]nixos/community.html">Community</a></li>

--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -23,7 +23,7 @@
 please open a <a
 href="https://github.com/NixOS/nixpkgs/pulls"><strong>pull request on
 GitHub</strong></a>, or <strong>send a patch</strong> to the <a
-href="[%root%]nixos/support.html#discourse"><tt>Discourse</tt> forum</a>. If you
+href="[%root%]nixos/learn.html#discourse"><tt>Discourse</tt> forum</a>. If you
 want to contribute regularly, you may want to ask for commit access to
 our GitHub repositories (please ask <a
 href="https://nixos.org/~eelco/">Eelco</a>, or on the <tt>#nixos</tt>

--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -147,6 +147,19 @@ then make a pull request.</p>
   channel</a>.</li>
 </ul>
 
+<h3>Commercial support</h3>
+<!-- Please submit a PR to add your company -->
+<p>For professional support, a number of consulting companies are
+available (sorted in alphabetical order):</p>
+<ul>
+  <li><a href="https://www.enlambda.com/">Enlambda</a></li>
+  <li><a href="https://nixos.mayflower.consulting">Mayflower</a></li>
+  <li><a href="https://nixcloud.io/">nixcloud</a></li>
+  <li><a href="https://www.numtide.com/">NumTide Ltd</a></li>
+  <li><a href="https://obsidian.systems">Obsidian Systems</a></li>
+  <li><a href="https://serokell.io/">Serokell</a></li>
+</ul>
+
 <h2>Donations</h2>
 
 <p>

--- a/nixos/community.tt
+++ b/nixos/community.tt
@@ -32,6 +32,14 @@ type="text/javascript"
 src="https://www.openhub.net/p/25550/widgets/project_basic_stats.js"></script>
 </div> </div>
 
+<h3><a href="https://github.com/NixOS/nixpkgs/issues">Bugs</a></h3>
+<p>If
+    you think you’ve found a bug, please report it in the <a
+    href="https://github.com/NixOS/nixpkgs/issues"><strong>Nixpkgs
+    issue tracker</strong></a> (please use the label <strong>6.topic:
+    nixos</strong>).
+</p>
+
 <h3>Documentation</h3>
 
 <ul>

--- a/nixos/learn.tt
+++ b/nixos/learn.tt
@@ -72,21 +72,6 @@
     </ul>
   </div>
 
-  <div class="span4">
-    <h2>Commercial support</h2>
-    <!-- Please submit a PR to add your company -->
-    <p>For professional support, a number of consulting companies are
-    available (sorted in alphabetical order):</p>
-    <ul>
-      <li><a href="https://www.enlambda.com/">Enlambda</a></li>
-      <li><a href="https://nixos.mayflower.consulting">Mayflower</a></li>
-      <li><a href="https://nixcloud.io/">nixcloud</a></li>
-      <li><a href="https://www.numtide.com/">NumTide Ltd</a></li>
-      <li><a href="https://obsidian.systems">Obsidian Systems</a></li>
-      <li><a href="https://serokell.io/">Serokell</a></li>
-    </ul>
-  </div>
-
 </div>
 
 [% END %]

--- a/nixos/learn.tt
+++ b/nixos/learn.tt
@@ -50,13 +50,6 @@
     href="mailto:nix-security-announce+subscribe@googlegroups.com">nix-security-announce+subscribe@googlegroups.com</a>.</p>
   </div>
 
-  <div class="span4"> <h2><a
-    href="https://github.com/NixOS/nixpkgs/issues">Bugs</a></h2> <p>If
-    you think you’ve found a bug, please report it in the <a
-    href="https://github.com/NixOS/nixpkgs/issues"><strong>Nixpkgs
-    issue tracker</strong></a> (please use the label <strong>6.topic:
-    nixos</strong>).</p>  </div>
-
 </div>
 
 <div class="row-fluid">

--- a/nixos/learn.tt
+++ b/nixos/learn.tt
@@ -1,4 +1,4 @@
-[% WRAPPER layout.tt title="NixOS support" menu='nixos' %]
+[% WRAPPER layout.tt title="Learning resources" menu='nixos' %]
 
 <div class="row-fluid">
 

--- a/nixos/learn.tt
+++ b/nixos/learn.tt
@@ -49,10 +49,6 @@
     Google Group</a> or send an email to <a
     href="mailto:nix-security-announce+subscribe@googlegroups.com">nix-security-announce+subscribe@googlegroups.com</a>.</p>
   </div>
-
-</div>
-
-<div class="row-fluid">
   <div class="span4">
     <h2>Other resources</h2>
     <p>There are several other manuals:</p>

--- a/nixos/wiki.tt
+++ b/nixos/wiki.tt
@@ -13,7 +13,7 @@
   <li><a href="[%root%]nix/manual/">Nix Manual</a> for help
     with the Nix expression language, Nix tools, and Nix's management
     model.</li>
-  <li><a href="[%root%]nixos/support.html">NixOS Support Page</a>
+  <li><a href="[%root%]nixos/learn.html">NixOS Support Page</a>
     on NixOS.org</li>
 </ul>
 


### PR DESCRIPTION
## Motivation

Whenever I'm looking for help or documentation, I find it difficult to find it under the word *Support*. 

I find *Learn* to be much clearer.

The idea is that if someone's at the NixOS homepage and looking for help, they're likely newbies (we all have the manuals in our browser histories already I presume).
Someone like that, in my opinion, wants to *learn* what Nix/NixOS is all about, rather than "receive support".

## Alternatives

*Documentation* would be another candidate, but we also point to Discourse/IRC rather than just the manual, meaning it's not a good fit.

*Help* is another good option, and I'm honestly not sure which is better between that and *learn*.

## Inspiration

This is inspired by Rust's excellent [home page](https://www.rust-lang.org/), and by discussions at the Documentation hackathon at NixCon 2019.

/cc @zimbatm @chreekat @layus @azazel75