### PR TITLE
nixos-site.css: Don't hyphenate code blocks

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -404,6 +404,9 @@ div.docbook code {
     color: inherit;
     font-size: 100%;
     white-space: normal;
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    hyphens: none;
 }
 
 div.docbook div.toc {
@@ -421,6 +424,9 @@ div.docbook pre.hljs {
 
 div.docbook span.command {
     font-family: Monaco, Menlo, Consolas, "Courier New", monospace; /* from bootstrap*/
+    -webkit-hyphens: none;
+    -moz-hyphens: none;
+    hyphens: none;
 }
 
 .license ul {


### PR DESCRIPTION
On some screen widths (notably those of mobile devices), code blocks can trigger hyphenation:

![Screenshot from 2019-12-24 13-27-50](https://user-images.githubusercontent.com/194893/71422751-6f051800-2652-11ea-9926-06810a870a14.png)

This can be confusing to users, since the hyphen isn't copied (it's just a CSS artifact), and could cause even more issues if the user is typing these instructions in from another device - in the paragraph just above the screenshot, there is a code block instructing the user to run `systemctl start display-manager` – the hyphen there matters since it's the actual name of the service.

This PR addresses that issue by preventing hyphenation of any `.command` and `.code` blocks, since it appears to be mostly the DocBook-related sections that are most affected:

![Screenshot from 2019-12-24 13-27-31](https://user-images.githubusercontent.com/194893/71422799-c30ffc80-2652-11ea-943c-99adaaa74ab7.png)
