### PR TITLE
Update packages-explorer to use relative paths.

### DIFF
--- a/packages-explorer/src/state.js
+++ b/packages-explorer/src/state.js
@@ -145,7 +145,7 @@ class State extends Component {
 	fetch_channels() {
 		this.setState({loading: this.state.loading + 1});
 
-		return fetch("/nixpkgs/packages-channels.json", {mode: "cors"})
+		return fetch("../nixpkgs/packages-channels.json", {mode: "cors"})
 			.then((response) => response.json())
 			.then((channels) => {
 				this.setState({
@@ -171,7 +171,7 @@ class State extends Component {
 		// Some (most?) development environment don't really like to serve .gz files.
 		const dev = window.DEVELOPMENT || hostname === "localhost" || hostname === "127.0.0.1";
 		const ext = dev ? "json" : "json.gz";
-		fetch(`/nixpkgs/packages-${channel}.${ext}`, {mode: "cors"})
+		fetch(`../nixpkgs/packages-${channel}.${ext}`, {mode: "cors"})
 			.then((response) => response.json())
 			.then((channel_data) => {
 				// Ensures we update only for the currently selected channel.


### PR DESCRIPTION
To save some seconds when doing the occasional lookup, I self-host a mirror of the NixOS `packages` and `options` pages. When serving from a subfolder, e.g. `http://localhost/nixos-homepage/nixos/packages.html`, the usage of absolute paths trips up the data fetching. Changing the paths to relative fixes that.