### PR TITLE
Remove latestNixOSRelease

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ favicon.png: logo/nixos-logo-only-hires.png
 nixos-release.tt:
 	uri=$$(curl --fail --silent -o /dev/null -w %{redirect_url} https://nixos.org/channels/nixos-${NIXOS_SERIES}); \
 	version=$$(echo $$uri | sed 's|.*/nixos-||'); \
-	echo "[%- latestNixOSSeries = \"${NIXOS_SERIES}\"; latestNixOSRelease = \"$$version\" -%]" > $@
+	echo "[%- latestNixOSSeries = \"${NIXOS_SERIES}\"; -%]" > $@
 
 %: %.in common.tt nix-release.tt
 	echo $$PATH

--- a/nixos-release.tt
+++ b/nixos-release.tt
@@ -1,1 +1,1 @@
-[%- latestNixOSSeries = "19.09"; latestNixOSRelease = "19.09.2158.d8652430c55" -%]
+[%- latestNixOSSeries = "19.09"; -%]

--- a/nixos/download.tt
+++ b/nixos/download.tt
@@ -29,7 +29,7 @@ installer as well as X11, Plasma 5 Desktop and several applications.  It’s a
 <em>live CD</em>, so it allows you to get an impression of NixOS (and
 the Nix package manager) before installing it.</p>
 
-[% prefix = "https://channels.nixos.org/nixos" %]
+[% prefix = "https://channels.nixos.org/nixos-" _ latestNixOSSeries %]
 
 <ul>
   <li><a href="[%prefix%]/latest-nixos-graphical-x86_64-linux.iso">Graphical live CD, 64-bit Intel/AMD</a> (<a href="[%prefix%]/latest-nixos-graphical-x86_64-linux.iso.sha256">SHA-256</a>)

--- a/nixos/download.tt
+++ b/nixos/download.tt
@@ -29,7 +29,7 @@ installer as well as X11, Plasma 5 Desktop and several applications.  It’s a
 <em>live CD</em>, so it allows you to get an impression of NixOS (and
 the Nix package manager) before installing it.</p>
 
-[% prefix = "https://releases.nixos.org/nixos" %]
+[% prefix = "https://channels.nixos.org/nixos" %]
 
 <ul>
   <li><a href="[%prefix%]/latest-nixos-graphical-x86_64-linux.iso">Graphical live CD, 64-bit Intel/AMD</a> (<a href="[%prefix%]/latest-nixos-graphical-x86_64-linux.iso.sha256">SHA-256</a>)

--- a/nixos/download.tt
+++ b/nixos/download.tt
@@ -3,8 +3,7 @@
 [% USE JSON.Escape %]
 
 <p>The latest stable release series is
-<strong>[%latestNixOSSeries%]</strong> and the latest release in that
-series is <strong>[%latestNixOSRelease%]</strong>.  Below are links to
+<strong>[%latestNixOSSeries%]</strong>.  Below are links to
 CD/DVD images and VirtualBox appliances containing the <a
 href="https://nixos.org/channels/nixos-[%latestNixOSSeries%]">latest
 release</a> in this series.  <a class="btn btn-large btn-success
@@ -30,10 +29,10 @@ installer as well as X11, Plasma 5 Desktop and several applications.  It’s a
 <em>live CD</em>, so it allows you to get an impression of NixOS (and
 the Nix package manager) before installing it.</p>
 
-[% prefix = "https://releases.nixos.org/nixos/" _ latestNixOSSeries _ "/nixos-" _ latestNixOSRelease %]
+[% prefix = "https://releases.nixos.org/nixos" %]
 
 <ul>
-  <li><a href="[%prefix%]/nixos-graphical-[%latestNixOSRelease%]-x86_64-linux.iso">Graphical live CD, 64-bit Intel/AMD</a> (<a href="[%prefix%]/nixos-graphical-[%latestNixOSRelease%]-x86_64-linux.iso.sha256">SHA-256</a>)
+  <li><a href="[%prefix%]/latest-nixos-graphical-x86_64-linux.iso">Graphical live CD, 64-bit Intel/AMD</a> (<a href="[%prefix%]/latest-nixos-graphical-x86_64-linux.iso.sha256">SHA-256</a>)
     <span class="label label-info">Recommended for most users</span></li>
 </ul>
 
@@ -42,8 +41,8 @@ and is therefore a lot smaller.  You have to run the installer from
 the console.  It contains a number of rescue tools.</p>
 
 <ul>
-  <li><a href="[%prefix%]/nixos-minimal-[%latestNixOSRelease%]-x86_64-linux.iso">Minimal installation CD, 64-bit Intel/AMD</a> (<a href="[%prefix%]/nixos-minimal-[%latestNixOSRelease%]-x86_64-linux.iso.sha256">SHA-256</a>)</li>
-  <li><a href="[%prefix%]/nixos-minimal-[%latestNixOSRelease%]-i686-linux.iso">Minimal installation CD, 32-bit Intel/AMD</a> (<a href="[%prefix%]/nixos-minimal-[%latestNixOSRelease%]-i686-linux.iso.sha256">SHA-256</a>)</li>
+  <li><a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso">Minimal installation CD, 64-bit Intel/AMD</a> (<a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso.sha256">SHA-256</a>)</li>
+  <li><a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso">Minimal installation CD, 32-bit Intel/AMD</a> (<a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso.sha256">SHA-256</a>)</li>
 </ul>
 
 </section>
@@ -60,7 +59,7 @@ appears, you can log in as <strong>user <tt>demo</tt></strong>,
 <tt>sudo -i</tt> in the KDE terminal (<tt>konsole</tt>).</p>
 
 <ul>
-  <li><a href="[%prefix%]/nixos-[%latestNixOSRelease%]-x86_64-linux.ova">VirtualBox appliance, 64-bit Intel/AMD</a> (<a href="[%prefix%]/nixos-[%latestNixOSRelease%]-x86_64-linux.ova.sha256">SHA-256</a>)</li>
+  <li><a href="[%prefix%]/latest-nixos-x86_64-linux.ova">VirtualBox appliance, 64-bit Intel/AMD</a> (<a href="[%prefix%]/latest-nixos-x86_64-linux.ova.sha256">SHA-256</a>)</li>
 </ul>
 
 </section>


### PR DESCRIPTION
This way we don't have to regenerate the download page whenever the channel updates.