### PR TITLE
Redirect hydra and nixops manuals to the latest hydra builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -53,3 +53,9 @@
   to = "https://github.com/NixOS/nixops"
   status = 301
   force = true
+
+[[redirects]]
+  from  = "/nixops/manual"
+  to = "https://hydra.nixos.org/job/nixops/master/tarball/latest/download-by-type/doc/manual"
+  status = 200
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -43,6 +43,12 @@
   force = true
 
 [[redirects]]
+  from  = "/hydra/manual"
+  to = "https://hydra.nixos.org/job/hydra/master/manual/latest/download-by-type/doc/manual"
+  status = 200
+  force = true
+
+[[redirects]]
   from  = "/nixops"
   to = "https://github.com/NixOS/nixops"
   status = 301


### PR DESCRIPTION
With the move to netlify, the hydra and nixops manuals vanished, without a redirect. Considering search engines link to those manuals, I believe it's mandatory we keep [cool URIs](https://www.w3.org/Provider/Style/URI.html) working. 

Use a "200" redirect.

> 200: "OK". Redirects with this status code will change the server response without changing the URL in the browser address bar. This is used for rewrites and proxying.

 * https://docs.netlify.com/routing/redirects/redirect-options/#http-status-codes

This will keep the nixos.org/.../manual URL in the address bar, but serve the contents proxied from the hydra result.