### PR TITLE
Add custom 404 page

### DIFF
--- a/404.tt
+++ b/404.tt
@@ -1,0 +1,16 @@
+[% WRAPPER layout.tt title="Not found" menu='nixos' %]
+
+<p>
+  The requested content <span class="at_url"></span> could not be found.
+</p>
+
+<script>
+// Enhance the error message with the URL when possible.
+$(function() {
+  var url = window.location.pathname;
+  $(".at_url").html(" at <tt class='url'></tt> ")
+  	.children(".url").text(url)
+})
+</script>
+
+[% END %]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ HTML = index.html news.html \
   nixos/security.html nixos/foundation.html \
   nixos/wiki.html \
   disnix/index.html disnix/download.html disnix/docs.html \
-  disnix/extensions.html disnix/examples.html disnix/support.html
+  disnix/extensions.html disnix/examples.html disnix/support.html \
+  404.html
 
 
 ### Prettify the NixOS manual.


### PR DESCRIPTION
Closes #343

![image](https://user-images.githubusercontent.com/132835/76710779-92cf7b80-66e0-11ea-9883-14e7de30c13b.png)

This works on top of automatic handling by Netlify:

> You can set up a custom 404 page for all paths that don't resolve to a static file. This doesn't require any redirect rules. If you add a 404.html page to your site, it will be picked up and displayed automatically for any failed paths.

 * https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling

* * *

I believe the small script to print the URL in the text body is important UX-wise. This will make end-user screenshots or text copy/paste more useful. Sure, it won't work for users who disable scripts, but that's their own decision. The text has been conceived with progressive enhancement in mind.

This is better than:

![image](https://user-images.githubusercontent.com/132835/76710821-f5c11280-66e0-11ea-9b6f-aa8ea770570b.png)
