### PR TITLE
remove search from the toolbar

### DIFF
--- a/layout.tt
+++ b/layout.tt
@@ -100,10 +100,6 @@
               <ul class="nav pull-right">
             [% END %]
 
-              <form class="navbar-search" method="get" action="https://www.google.com/search">
-                <input name="q" type="text" class="search-query span2" placeholder="Search nixos.org"/>
-                <input name="sitesearch" type="hidden" value="nixos.org"/>
-              </form>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
nixos.org is already index in all the search engines and this is what most people use and search now days happens outside the website. This would of-course not be true if our search would be very tightly integrated with nixos.org.

Other websites I checked (kubernets.io, rust-lang.io) out also don't include this kind of search (full text over all sites) and just rely on google to index them.

I do think we "expose" more search over existing packages and nixos options but that would take some time to get there. first step would be to remove this search in the first place.

