### PR TITLE
Strip nix store paths from source nixpkgs in packages.json

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
         nix-env -f '<nixpkgs>' -I nixpkgs=${src} -qa --json --arg config 'import ${./packages-config.nix}' >> tmp
         echo -n '}' >> tmp
         mkdir $out
-        < tmp sed "s|$$nixpkgs/||g" | jq -c . > $out/packages.json
+        < tmp sed "s|${src}/||g" | jq -c . > $out/packages.json
       '';
 
     packages.x86_64-linux = {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,15 @@
         echo -n '}' >> tmp
         mkdir $out
         < tmp sed "s|${src}/||g" | jq -c . > $out/packages.json
+
+        # Validate we don't keep references.
+        # The [^/] part of the expression could be changed for a better
+        # representation of a nix store path.
+        if jq < $out/packages.json | grep '/nix/store/[^/]+/'; then
+          echo "Errant nix store paths in packages.json output."
+          echo "See previous output as grepped."
+          exit 1
+        fi
       '';
 
     packages.x86_64-linux = {


### PR DESCRIPTION
This removes the accidental inclusion of /nix/store paths in the packages.json file.

This was part of the original expression:

```
| sed "s|$$nixpkgs/||g" | jq -c . > $@.tmp
```

It was kept as-is, while it's not a Makefile anymore.

Fixes #349.