### PR TITLE
add news date for Release 20.03

### DIFF
--- a/news.xml
+++ b/news.xml
@@ -2,7 +2,7 @@
 
 <news>
   <item>
-    <pubDate>TODO</pubDate>
+    <pubDate>Mon, 20 Apr 2020 23:27:10 GMT</pubDate>
     <title>
       NixOS 20.03 released
     </title>


### PR DESCRIPTION
add news date for Release 20.03 using the merge time of NixOS/nixos-homepage#392 (f02e80c7985f1c5ae7659a81ed914c0fcbfcb880)

/cc @worldofpeace