### PR TITLE
Misc fixes around the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ To automatically rebuild on every change:
 
     [nix-shell]$ git ls-files | entr make
 
+To test the complete result from a nix-build:
+
+    $ nix-build
+    $ nix-shell --run 'python -m http.server 8000 --directory result'
+
 ## License
 
 The content of the website is licensed under the [Creative Commons Attribution Share Alike 4.0 International](LICENSES/CC-BY-SA-4.0.txt) license.

--- a/news.tt
+++ b/news.tt
@@ -1,4 +1,4 @@
-[% WRAPPER layout.tt title="News" menu='organization' %]
+[% WRAPPER layout.tt title="News" menu='nixos' %]
 
 [% INSERT "all-news.xhtml" %]
 

--- a/nix/index.tt
+++ b/nix/index.tt
@@ -36,7 +36,7 @@
 
     <p>GPG verification instructions, source tarballs and more
     installation information are <a
-    href="[%root%]nix/download.html">available</a>.</p>
+    href="[%root%]download.html">available</a>.</p>
 
   [% END %]
   </div>

--- a/nixos/index.tt
+++ b/nixos/index.tt
@@ -19,7 +19,7 @@
 
   <div class="get-nixos get-button">
   <a class="btn btn-large btn-success"
-  href="[%root%]nixos/download.html"><i class="fa
+  href="[%root%]download.html"><i class="fa
   fa-cloud-download"></i> Get NixOS</a>
   </div>
 </div>


### PR DESCRIPTION
This ended up smaller than intended, as I decided not to bring in some no-op changes from the (upcoming) re-css PR.

They are the changes that are not specific to re-working the CSS.

* * *

This:

 * Fixes some links half-broken by moving the download.html page
 * Removes use of an unmaintained/unused menu in news.html

Additionally, this documents how to use the python http server with the `result` symlink if you need/want to test with `nix-build`.

What's that with half-broken links? They do work on the website, because of the redirects. Though they don't work on a local setup because the netlify redirect are not available there.