### PR TITLE
Use fd to rebuild untracked files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ then open http://127.0.0.1:8000/index.html
 
 To automatically rebuild on every change:
 
-    [nix-shell]$ git ls-files | entr make
+    [nix-shell]$ fd | entr make
 
 To test the complete result from a nix-build:
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,8 @@
         enableParallelBuilding = true;
 
         buildInputs =
-          [ libxslt
+          [ fd
+            libxslt
             libxml2
             perl
             perlPackages.JSON


### PR DESCRIPTION
```
Fixes #410

`git ls-files` only traces files that are already in Git. When adding
new content, this is inconvenient. `fd` searches the entire directory
irrespective of the files' status in Git. However, it still respects
.gitignore files, so that it ignores build artifacts.
```

Hm… this is my first time touching a flake. Traditionally I would have added this package to `shell.nix`. Is it okay to add it under `buildInputs`, even though it is only developer tooling? Or do we have a better place for such things?

By the way git was also not in there… of course, everyone has Git already, making this rarely a practical problem. But still in a pure nix-shell `git ls-files | entr make` fails.