### PR TITLE
Update to use `nix shell` instead of `nix run`

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-UPDATE=1 nix run nixpkgs#gnumake nixpkgs#curl -c make update --keep-going
+UPDATE=1 nix shell nixpkgs#gnumake nixpkgs#curl -c make update --keep-going
 
 nix flake update \
   --update-input released-nixpkgs \


### PR DESCRIPTION
This was renamed upstream, see https://github.com/NixOS/nix/pull/3551

For reference, I ran into this here: https://github.com/NixOS/nixos-homepage/pull/418/checks?check_run_id=663327024