### PR TITLE
homepage: Fix horizontal scroll on narrower widths

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -507,12 +507,22 @@ ul.comma-separated > li:last-of-type:after {
   }
 }
 
-#examples {
-  margin: 0;
-  margin-top: 30px;
-  padding: 1em;
-  border: 1px solid #DDDDDD;
-  border-radius: 2px;
+@media (min-width: 768px) {
+  #examples {
+    margin: 0;
+    margin-top: 30px;
+    padding: 1em;
+    border: 1px solid #DDDDDD;
+    border-radius: 2px;
+  }
+}
+
+.asciinema-player-wrapper {
+  margin-top: 2em;
+}
+
+#examples h2 {
+  border: 0;
 }
 
 #examples pre.well {
@@ -520,13 +530,25 @@ ul.comma-separated > li:last-of-type:after {
   background: #333333;
   border-color: #333333;
   color: #FFFFFF;
+  white-space: pre;
+  overflow-x: auto;
 }
 
-#examples h2 {
-  border: 0;
+@media (min-width: 768px) {
+  .asciinema-player-wrapper {
+    width: 570px;
+  }
 }
 
-.asciinema-player-wrapper {
-  margin-top: 2em;
-  width: 570px;
+/* Keep the player usable when the viewport is narrow */
+@media (max-width: 767px) {
+  /* Completely fill the width of the display on narrow displays. */
+  .asciinema-player-wrapper {
+    position: relative;
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+  .asciinema-player-wrapper .asciinema-player {
+    overflow: auto;
+  }
 }

--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -534,12 +534,6 @@ ul.comma-separated > li:last-of-type:after {
   overflow-x: auto;
 }
 
-@media (min-width: 768px) {
-  .asciinema-player-wrapper {
-    width: 570px;
-  }
-}
-
 /* Keep the player usable when the viewport is narrow */
 @media (max-width: 767px) {
   /* Completely fill the width of the display on narrow displays. */
@@ -550,5 +544,24 @@ ul.comma-separated > li:last-of-type:after {
   }
   .asciinema-player-wrapper .asciinema-player {
     overflow: auto;
+  }
+}
+
+/* [767 - 1158] */
+
+/* Imitates the span6/span6 layout, but in a more flexible manner */
+@media (min-width: 980px) {
+  .hero.side-by-side {
+    display: flex;
+  }
+  .hero.side-by-side > * {
+  }
+  .asciinema-player-wrapper {
+    width: 570px;
+  }
+}
+@media (max-width: 979px) {
+  .hero .hero-demo {
+    text-align: center;
   }
 }

--- a/index.tt
+++ b/index.tt
@@ -6,8 +6,8 @@
 
 <link rel="alternate" type="application/rss+xml" title="RSS" href="/news-rss.xml" />
 
-<div class="row-fluid">
-  <div class="span6">
+<div class="side-by-side hero">
+  <div>
     <h1>Reproducible builds and deployments.</h1>
     <p class="lead">
       <strong>Nix</strong> is a powerful package manager for Linux and other
@@ -24,7 +24,7 @@
     <a class="btn btn-large" href="[% root %]learn.html">Get started</a>
   </div>
 
-  <div class="span6">
+  <div class="hero-demo">
     <asciinema-player cols="77" rows="24" src="/demo.cast"></asciinema-player>
   </div>
 </div>


### PR DESCRIPTION
This is not trivially screenshotable, you have to compare by resizing the window.

I had to break out of bootstrap for the side-by-side "hero" unit, I can't see a non-hacky way full of custom rules compared to letting the flexbox layout deal with it.

Note that this also adds overflow-x to all the examples at the bottom, which otherwise would be wrapped weirdly. I find that neither options (wrapping weirdly or scrollbars) are satisfactory on wider widths, but on phone widths I know for sure scrolling horizontally those examples is better.

The asciinema box **will be weird**. I don't know if we can somehow make its text automagically rather than force an horizontal scroll (or worse, cutting off according to its defaults!).