### PR TITLE
Fix a broken link

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -66,7 +66,7 @@
   <div class="span12">
     <h1>Choose from Thousands of Packages</h1>
     <p class="text-center lead">
-      The Nix Packages collection (<a href="https://github/NixOS/nixpkgs">nixpkgs</a>) is a set of
+      The Nix Packages collection (<a href="https://github.com/NixOS/nixpkgs">nixpkgs</a>) is a set of
       <strong>over 60 000 packages</strong> for the Nix package manager.
     </p>
     <form>


### PR DESCRIPTION
The link previously had github instead of github.com