### PR TITLE
Migrate the security teams GPG key download to keys.openpgp.org

### DIFF
--- a/teams/security.tt
+++ b/teams/security.tt
@@ -43,13 +43,10 @@
       <a href="mailto:graham@grahamc.com">graham@grahamc.com</a>
       (gchristensen)
       <br />
-      <strong>GPG Key:</strong>
-      <tt>
-        <a href="https://pgp.mit.edu/pks/lookup?op=get&amp;search=0xFE918C3A98C1030F">0xFE918C3A98C1030F</a>
-      </tt>
-      <br />
       <strong>GPG Fingerprint:</strong>
-      <tt>BA94 FDF1 1DA4 0521 2864  C121 FE91 8C3A 98C1 030F</tt>
+      <tt>
+        <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/BA94FDF11DA405212864C121FE918C3A98C1030F">BA94 FDF1 1DA4 0521 2864  C121 FE91 8C3A 98C1 030F</a>
+      </tt>
     </p>
   </li>
   <li>
@@ -58,13 +55,10 @@
        <a href="mailto:fpletz@fnordicwalking.de">fpletz@fnordicwalking.de</a>
        (fpletz)
        <br />
-       <strong>GPG Key:</strong>
-       <tt>
-         <a href="https://pgp.mit.edu/pks/lookup?op=get&amp;search=0x846FDED7792617B4">0x846FDED7792617B4</a>
-       </tt>
-       <br />
        <strong>GPG Fingerprint:</strong>
-       <tt>8A39 615D CE78 AF08 2E23  F303 846F DED7 7926 17B4</tt>
+       <tt>
+         <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/8A39615DCE78AF082E23F303846FDED7792617B4">8A39 615D CE78 AF08 2E23 F303 846F DED7 7926 17B4</a>
+       </tt>
     </p>
   </li>
   <li>


### PR DESCRIPTION
The old SKS system is flawed and shouldn't be used anymore. Hagrid (https://sequoia-pgp.org/blog/2019/06/14/20190614-hagrid/) is a relatively new key of replacement for the old SKS system. It strips the signatures from the keys, to prevent key poisoning, so the WoT is dead and gone.

Also key ids  can be cheaply forged, even long ones, see:
  - https://debian-administration.org/users/dkg/weblog/105
  - https://mailarchive.ietf.org/arch/msg/openpgp/Al8DzxTH2KT7vtFAgZ1q17Nub_g/

Therefore let's migrate to https://keys.openpgp.net and drop key ids entirely.