### PR TITLE
added install and clean targets update flake.nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,14 @@ $(NIXPKGS_MANUAL_OUT): $(NIXPKGS_MANUAL_IN) bootstrapify-docbook.sh bootstrapify
 
 all: $(HTML) favicon.png favicon.ico robots.txt $(subst .png,-small.png,$(filter-out %-small.png,$(wildcard images/screenshots/*)))
 
+install:
+	fd -I -t d -x mkdir -p build/{}   
+	fd -I -t f -t l '(.*?)\.(gpg|svg|xml|ico|css|jpg|gif|doc|pdf|html|png|js|cast|ico|robots.txt)$$' -x cp -a {} build/{}
+
+clean:
+	rm -rf build 
+
+
 
 robots.txt: $(HTML)
 	echo "Users-agent: *" >> $@

--- a/flake.nix
+++ b/flake.nix
@@ -70,8 +70,9 @@
           ];
 
         installPhase = ''
+	  make install
           mkdir $out
-          cp -prd . $out/
+          cp -prd build/. $out/
         '';
 
         shellHook = ''


### PR DESCRIPTION
This add two new targets (install, clean)

install , which scoops up the artefacts from the build process to build/

flake.nix modified to to make install and copy the build/ dir to $out.

the better way is to modify the make file entirely, but it's not a simple as it seems.

also this might break deployment to netify??????


