### PR TITLE
Implement local link checking as part of build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ latest-news.xhtml: news.xml news.xsl
 	xsltproc --param maxItem 12 news.xsl news.xml > $@ || rm -f $@
 
 check:
-	checklink $(HTML)
+	linkchecker $(HTML)
 
 blogs.xml:
 	curl --fail https://planet.nixos.org/rss20.xml > $@.tmp

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ latest-news.xhtml: news.xml news.xsl
 	xsltproc --param maxItem 12 news.xsl news.xml > $@ || rm -f $@
 
 check: $(HTML)
-	linkchecker $(HTML)
+	bash check-links.sh
 
 blogs.xml:
 	curl --fail https://planet.nixos.org/rss20.xml > $@.tmp

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ favicon.ico: favicon.png
 %-small.png: %.png
 	convert -resize 200 $< $@
 
-%.html: %.tt layout.tt common.tt 
+%.html: %.tt layout.tt common.tt
 	tpage \
 	  --pre_chomp --post_chomp \
 	  --define root=$(ROOT) \

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ index.html: news-rss.xml latest-news.xhtml blogs.json
 latest-news.xhtml: news.xml news.xsl
 	xsltproc --param maxItem 12 news.xsl news.xml > $@ || rm -f $@
 
-check:
+check: $(HTML)
 	linkchecker $(HTML)
 
 blogs.xml:

--- a/check-links.sh
+++ b/check-links.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+caddy -port 8080 &
+server_pid=$!
+linkchecker http://localhost:8080
+status=$?
+kill $server_pid
+exit $status

--- a/check-links.sh
+++ b/check-links.sh
@@ -1,8 +1,10 @@
 #! /usr/bin/env bash
 
-caddy -port 8080 &
+LINKCHECK_PORT=8137
+
+caddy -port $LINKCHECK_PORT &
 server_pid=$!
-linkchecker http://localhost:8080 \
+linkchecker http://localhost:$LINKCHECK_PORT \
     --ignore-url /nixpkgs/
 status=$?
 kill $server_pid

--- a/check-links.sh
+++ b/check-links.sh
@@ -2,7 +2,8 @@
 
 caddy -port 8080 &
 server_pid=$!
-linkchecker http://localhost:8080
+linkchecker http://localhost:8080 \
+    --ignore-url /nixpkgs/
 status=$?
 kill $server_pid
 exit $status

--- a/features.tt
+++ b/features.tt
@@ -168,7 +168,7 @@ upgrades.</p>
     <h3>Nix Packages collection</h3>
 
     <p>We provide a large set of Nix expressions containing thousands of
-      existing Unix packages, the <a href="../nixpkgs"><em>Nix Packages
+      existing Unix packages, the <a href="https://github.com/NixOS/nixpkgs"><em>Nix Packages
           collection</em> (Nixpkgs)</a>.</p>
 
 
@@ -246,7 +246,7 @@ upgrades.</p>
 
     <p>In NixOS, the entire operating system — the kernel, applications,
       system packages, configuration files, and so on — is built by the
-      <a href="/nix/">Nix package manager</a> from a
+      <a href="/">Nix package manager</a> from a
       description in a purely
       functional build language. The fact that it’s purely functional
       essentially means that building a new configuration cannot overwrite
@@ -404,7 +404,7 @@ upgrades.</p>
     <section>
       <h2>How does NixOS work?</h2>
 
-      <p>NixOS is based on <a href="/nix">Nix</a>, a purely functional
+      <p>NixOS is based on <a href="/">Nix</a>, a purely functional
         package management system. Nix stores all packages in isolation from
         each other under paths such as</p>
 
@@ -461,7 +461,7 @@ upgrades.</p>
           (e.g., Apache HTTPD, PostgreSQL, and Tomcat) that can be configured
           declaratively through <tt>configuration.nix</tt>.</li>
 
-        <li>NixOS build on the <a href="/nixpkgs">Nix Packages
+        <li>NixOS build on the <a href="https://github.com/NixOS/nixpkgs">Nix Packages
             collection</a> (Nixpkgs), which provides Nix expressions for over
           40 000 packages that you can install under NixOS.</li>
 

--- a/features.tt
+++ b/features.tt
@@ -245,7 +245,8 @@ upgrades.</p>
     <h3>Declarative system configuration model</h3>
 
     <p>In NixOS, the entire operating system — the kernel, applications,
-      system packages, configuration files, and so on — is built by the <a href="/nix">Nix package manager</a> from a
+      system packages, configuration files, and so on — is built by the
+      <a href="/nix/">Nix package manager</a> from a
       description in a purely
       functional build language. The fact that it’s purely functional
       essentially means that building a new configuration cannot overwrite

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
               fd
               libxslt
               libxml2
+              linkchecker
               perl
               perlPackages.JSON
               perlPackages.XMLSimple

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
           enableParallelBuilding = true;
 
           buildInputs = with pkgs; [
+              caddy
               fd
               libxslt
               libxml2
@@ -83,6 +84,8 @@
               "PACKAGES_EXPLORER=${packagesExplorer}/bundle.js"
               "NIX_PILLS_MANUAL_IN=${nixPills}/share/doc/nix-pills"
             ];
+
+          doCheck = true;
 
           installPhase = ''
             mkdir $out

--- a/news.xml
+++ b/news.xml
@@ -124,7 +124,7 @@
       NixOS 19.09 “Loris” has been released, the twelfth stable release branch.
       See the <a href="/nixos/manual/release-notes.html#sec-release-19.09">release notes</a>
       for details. You can get NixOS 19.09 ISOs and VirtualBox appliances
-      from the <a href="nixos/download.html">download page</a>.
+      from the <a href="/download.html">download page</a>.
       For information on how to upgrade from older release branches
       to 19.09, check out the
       <a href="/nixos/manual/index.html#sec-upgrading">manual section on upgrading</a>.
@@ -143,7 +143,7 @@
       NixOS 19.03 “Koi” has been released, the eleventh stable release branch.
       See the <a href="/nixos/manual/release-notes.html#sec-release-19.03">release notes</a>
       for details. You can get NixOS 19.03 ISOs and VirtualBox appliances
-      from the <a href="nixos/download.html">download page</a>.
+      from the <a href="/download.html">download page</a>.
       For information on how to upgrade from older release branches
       to 19.03, check out the
       <a href="/nixos/manual/index.html#sec-upgrading">manual section on upgrading</a>.
@@ -163,7 +163,7 @@
       NixOS 18.09 “Jellyfish” has been released, the tenth stable release branch.
       See the <a href="/nixos/manual/release-notes.html#sec-release-18.09">release notes</a>
       for details. You can get NixOS 18.09 ISOs and VirtualBox appliances
-      from the <a href="nixos/download.html">download page</a>.
+      from the <a href="/download.html">download page</a>.
       For information on how to upgrade from older release branches
       to 18.09, check out the
       <a href="/nixos/manual/index.html#sec-upgrading">manual section on upgrading</a>.
@@ -235,7 +235,7 @@
       NixOS 18.03 “Impala” has been released, the ninth stable release branch.
       See the <a href="/nixos/manual/release-notes.html#sec-release-18.03">release notes</a>
       for details. You can get NixOS 18.03 ISOs and VirtualBox appliances
-      from the <a href="nixos/download.html">download page</a>.
+      from the <a href="/download.html">download page</a>.
       For information on how to upgrade from older release branches
       to 18.03, check out the
       <a href="/nixos/manual/index.html#sec-upgrading">manual section on upgrading</a>.
@@ -263,7 +263,7 @@
       NixOS 17.09 “Hummingbird” has been released, the eigth stable release
       branch. See the <a href="/nixos/manual/release-notes.html#sec-release-17.09">release notes</a>
       for details. You can get NixOS 17.09 ISOs and VirtualBox
-      appliances from the <a href="nixos/download.html">download
+      appliances from the <a href="/download.html">download
         page</a>. For information on how to upgrade from older release
       branches to 17.09, check out the <a href="/nixos/manual/index.html#sec-upgrading">manual section on
         upgrading</a>.
@@ -306,7 +306,7 @@
       NixOS 17.03 “Gorilla” has been released, the seventh stable release
       branch. See the <a href="/nixos/manual/release-notes.html#sec-release-17.03">release notes</a>
       for details. You can get NixOS 17.03 ISOs and VirtualBox
-      appliances from the <a href="nixos/download.html">download
+      appliances from the <a href="/download.html">download
         page</a>. For information on how to upgrade from older release
       branches to 17.03, check out the <a href="/nixos/manual/index.html#sec-upgrading">manual section on
         upgrading</a>.
@@ -322,7 +322,7 @@
       NixOS 16.09 “Flounder” has been released, the sixth stable release
       branch. See the <a href="/nixos/manual/release-notes.html#sec-release-16.09">release notes</a>
       for details. You can get NixOS 16.09 ISOs and VirtualBox
-      appliances from the <a href="nixos/download.html">download
+      appliances from the <a href="/download.html">download
         page</a>. For information on how to upgrade from older release
       branches to 16.09, check out the <a href="/nixos/manual/index.html#sec-upgrading">manual section on
         upgrading</a>.
@@ -351,7 +351,7 @@
       NixOS 16.03 “Emu” has been released, the fifth stable release
       branch. See the <a href="/nixos/manual/release-notes.html#sec-release-16.03">release notes</a>
       for details. You can get NixOS 16.03 ISOs and VirtualBox
-      appliances from the <a href="nixos/download.html">download
+      appliances from the <a href="/download.html">download
         page</a>. For information on how to upgrade from older release
       branches to 16.03, check out the <a href="/nixos/manual/index.html#sec-upgrading">manual section on
         upgrading</a>.
@@ -379,7 +379,7 @@
       NixOS 15.09 “Dingo” has been released, the fourth stable release
       branch. See the <a href="/nixos/manual/release-notes.html#sec-release-15.09">release notes</a>
       for details. You can get NixOS 15.09 ISOs and VirtualBox
-      appliances from the <a href="nixos/download.html">download
+      appliances from the <a href="/download.html">download
         page</a>. For information on how to upgrade from older release
       branches to 15.09, check out the <a href="/nixos/manual/index.html#sec-upgrading">manual section on
         upgrading</a>.
@@ -450,7 +450,7 @@
       release branch. It brings Linux 3.14, systemd 217, Glibc 2.20,
       KDE 4.14.1, and much more. See the <a href="/nixos/manual/sec-release-14.12.html">release notes</a>
       for details. You can get NixOS 14.12 ISOs and VirtualBox
-      appliances from the <a href="nixos/download.html">download
+      appliances from the <a href="/download.html">download
         page</a>. For information on how to upgrade from older release
       branches to 14.12, check out the <a href="/nixos/manual/sec-upgrading.html">manual section on
         upgrading</a>.
@@ -494,7 +494,7 @@
       Glibc 2.19, KDE 4.12, light-weight NixOS containers, and much
       more. See the <a href="/nixos/manual/#sec-release-14.04">release
         notes</a> for details. You can get NixOS 14.04 ISOs and
-      VirtualBox appliances from the <a href="nixos/download.html">download page</a>. For information on
+      VirtualBox appliances from the <a href="/download.html">download page</a>. For information on
       how to upgrade a 13.10 system to 14.04, check out the <a href="/nixos/manual/#sec-upgrading">manual
         section on upgrading</a>.
     </description>
@@ -589,7 +589,7 @@ $ nix-store -qR /run/current-system | grep openssl
       that need bug fixes and security updates, but not the
       potentially destabilising changes that sometimes occur on the
       unstable branch. You can get NixOS 13.10 ISOs and VirtualBox
-      appliances from the <a href="nixos/download.html">download
+      appliances from the <a href="/download.html">download
         page</a>. See the <a href="https://nixos.org/nix-dev/2013-October/011941.html">announcement</a>
       for more information. For information on how to switch an
       existing NixOS machine from the unstable channel to 13.10, check
@@ -944,7 +944,7 @@ $ nix-store -qR /run/current-system | grep openssl
       ISSRE paper on NixOS-based system testing
     </title>
     <description>
-      The paper <a href="docs/papers.html#issre10">“Automating System
+      The paper <a href="https://edolstra.github.io/pubs/decvms-issre2010-final.pdf">“Automating System
         Tests Using Declarative Virtual Machines”</a> (by Sander van der
       Burg and Eelco Dolstra) has been accepted for presentation at
       the <a href="http://www.issre2010.org/">21st IEEE International
@@ -1433,10 +1433,10 @@ $ nix-store -qR /run/current-system | grep openssl
     </title>
     <description>
       <p>
-        Eelco Dolstra presented the paper <a href="docs/papers.html#hotos07"><em>Purely Functional System
-            Configuration Management</em></a> at the <a href="https://www.usenix.org/events/hotos07/">11th Workshop on
-          Hot Topics in Operating Systems (HotOS XI)</a>. It gives an
-        overview of the ideas behind <a href="nixos">NixOS</a>. The
+        Eelco Dolstra presented the paper <a href="https://edolstra.github.io/pubs/hotos-final.pdf"><em>Purely Functional System
+        Configuration Management</em></a> at the <a href="https://www.usenix.org/events/hotos07/">11th Workshop on
+        Hot Topics in Operating Systems (HotOS XI)</a>. It gives an
+        overview of the ideas behind <a href="nixos/">NixOS</a>. The
         <a href="http://people.cs.uu.nl/eelco/talks/hotos-may-2007.pdf">slides</a>
         are also available.
       </p>
@@ -1603,7 +1603,7 @@ $ nix-store -qR /run/current-system | grep openssl
     </title>
     <description>
       <a href="http://www.cs.uu.nl/~eelco">Eelco Dolstra</a>
-      defended his <a href="docs/papers.html#dolstra06thesis">PhD
+        defended his <a href="https://edolstra.github.io/pubs/phd-thesis.pdf">PhD
         thesis</a> on the purely functional deployment model.
     </description>
   </item>


### PR DESCRIPTION
This was #483, addresses part of #481.

Now with preview ;)

This was a bit more involved than initially anticipated. I don't think it's feasible to test local files without a webserver, as the file path semantics are different. There were a bunch of false negatives, as linkchecker simply ignored paths like `/nixpkgs` as they are outside the domain – and they would not work, as they translate to `file:///nixpkgs`.

Starting a local webserver is a heavier approach, but solves the issue. Here I chose caddy instead of, say, `python -m http.server`, because it is quite a bit faster, yet still zero-configuration for this use case. (I also considered lighttpd and busybox httpd, both of which had unsuitable default configurations.)

The `/pkgs/...` routes from the nixpkgs manual are ignored, because I think this issue should likely be solved upstream. Even without checking the nixpkgs manual, this setup provides significant value to guard against dead link regressions.

An end-to-end link check against deployed https://nixos.org is out of scope for this PR.