### PR TITLE
index: do not use IDs for styles

### DIFF
--- a/css/nixos-site.css
+++ b/css/nixos-site.css
@@ -496,19 +496,19 @@ ul.comma-separated > li:last-of-type:after {
  */
 
 @media (min-width: 980px) {
-  #packages-search .input-append button.btn {
+  .packages-searchbox .input-append button.btn {
     font-size: 28px;
     height: 54px;
   }
 
-  #packages-search .input-append input {
+  .packages-searchbox .input-append input {
     font-size: 28px;
     height: 44px;
   }
 }
 
 @media (min-width: 768px) {
-  #examples {
+  .home-examples {
     margin: 0;
     margin-top: 30px;
     padding: 1em;
@@ -521,11 +521,11 @@ ul.comma-separated > li:last-of-type:after {
   margin-top: 2em;
 }
 
-#examples h2 {
+.home-examples h2 {
   border: 0;
 }
 
-#examples pre.well {
+.home-examples pre.well {
   margin-top: 1em;
   background: #333333;
   border-color: #333333;

--- a/index.tt
+++ b/index.tt
@@ -62,7 +62,7 @@
 
 <hr />
 
-<div id="packages-search" class="row-fluid text-center">
+<div id="packages-search" class="row-fluid text-center packages-searchbox">
   <div class="span12">
     <h1>Choose from Thousands of Packages</h1>
     <p class="text-center lead">
@@ -83,7 +83,7 @@
 
 <h1 class="text-center">Examples...</h1>
 
-<div id="examples">
+<div class="home-examples">
 
   <section>
     <div class="row-fluid">


### PR DESCRIPTION
The unused IDs were removed.

Fix #489

Note that I haven't removed the use of IDs for other parts. They are probably are not causing conflicts. In the future rework of the site, we'll have to be more mindful and use something like [rscss](https://rscss.io/). And anyway they are pretty well scoped so the risks are quite small.