### PR TITLE
Remove Governance from menu

### DIFF
--- a/layout.tt
+++ b/layout.tt
@@ -41,7 +41,6 @@
             <li><a href="[%root%]download.html">Download</a></li>
             <li><a href="[%root%]learn.html">Learn</a></li>
             <li><a href="[%root%]community.html">Community</a></li>
-            <li><a href="[%root%]governance.html">Governance</a></li>
             <li><a href="[%root%]donate.html">Donate</a></li>
           </ul>
           <ul class="nav pull-right">


### PR DESCRIPTION
It is not that important that it should be in the menu. It's fine to be in the footer next to security.

People that are more interested in the project will find it there.

Removing it **now** will help the redesign process.