### PR TITLE
Fix guides titles (<title>)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ NIX_DEV_MANUAL_OUT = guides
 
 all: $(NIX_DEV_MANUAL_OUT) learn_guides.html.in
 
-$(NIX_DEV_MANUAL_OUT) learn_guides.html.in: $(NIX_DEV_MANUAL_IN) layout.tt
+$(NIX_DEV_MANUAL_OUT) learn_guides.html.in: $(NIX_DEV_MANUAL_IN) layout.tt copy-nix-dev-tutorials.sh
 	bash copy-nix-dev-tutorials.sh $(NIX_DEV_MANUAL_OUT)
 
 

--- a/copy-nix-dev-tutorials.sh
+++ b/copy-nix-dev-tutorials.sh
@@ -26,8 +26,7 @@ for page in "${pages[@]}"; do
 
   echo "<li><a href=\"/$outDir/$filename.html\">$title</a></li>" >> learn_guides.html.in
 
-  echo '[% WRAPPER layout.tt title="Guides - $title" %]' > $target
-  echo '' >> $target
+  printf '[%% WRAPPER layout.tt title="Guides - %s" %%]\n\n' "$title" > $target
 
   xidel $source --css '.body > *' --printed-node-format=html \
     | sed 's|<a class=\"headerlink\".*<\/a>||g' \
@@ -37,6 +36,5 @@ for page in "${pages[@]}"; do
     | sed 's|../reference/pinning-nixpkgs.html#ref-pinning-nixpkgs|towards-reproducibility-pinning-nixpkgs.html|g' \
       >> "$target"
 
-  echo '' >> $target
-  echo "[% END %]" >> $target
+  printf '\n\n[%% END %%]\n' >> $target
 done


### PR DESCRIPTION

The title was using what amounted to:

```
echo '[% $title %]' > file.tt
```

Which put the literal `$title` perl variable, which in Template Toolkit,
an undefined variable is equivalent to an empty string.

This made the <title /> of the page be "NixOS - Guides - ".

This fixes that by using the better `printf` building for building
strings to print.

Additionally we can drop the empty echoes and use `\n` as printf honours
them.

* * *

In addition, mark the script as an input of those generated files.