### PR TITLE
Remove pre-nixcon survey link. Keep nixcon banner

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -8,7 +8,6 @@
 
 <div class="alert alert-info">
   This year's <a href="https://2020.nixcon.org/">NixCon</a> will take place <b>online</b> on <b>October 16th-18th 2020</b>. It is a community-oriented conference for contributors and users of Nix and NixOS.<br />
-  Please help the organizers to plan the event by filling out <a href="https://nixcon.limequery.org/">this survey</a>!
 </div>
 
 <div class="side-by-side">


### PR DESCRIPTION
We're closing the pre-event survey.

I figure that it is good to keep the NixCon 2020 banner itself until the event is completed.

CC @davidak @garbas 