### PR TITLE
redesign: misc. fixes for asciinema panes

### DIFF
--- a/js/nixos-site.js
+++ b/js/nixos-site.js
@@ -27,6 +27,18 @@ $(function () {
     $("body").toggleClass("-debug");
   });
 
+  $(".pane-asciinemaplayer").each(function () {
+    var player = $(this).find("asciinema-player")[0];
+
+    this.addEventListener("paneOpen", function (e) {
+      player.play();
+    });
+
+    this.addEventListener("paneClose", function (e) {
+      player.pause();
+    });
+  });
+
   $("[data-fullscreen-pane]").each(function () {
     var $source = $(this);
     var $pane = $($source.attr("href"));

--- a/js/nixos-site.js
+++ b/js/nixos-site.js
@@ -3,6 +3,10 @@ $(function () {
   // activating an event. In that case some semantics are different.
   var $$synthetic = false;
 
+  // Custom event types
+  var paneOpenEvent = new Event("paneOpen");
+  var paneCloseEvent = new Event("paneClose");
+
   // Setup the responsive collapsible menu
   var $header = $("body > header");
   var $menu = $("body > header nav");
@@ -26,10 +30,13 @@ $(function () {
   $("[data-fullscreen-pane]").each(function () {
     var $source = $(this);
     var $pane = $($source.attr("href"));
+    var pane = $pane[0];
 
     // Wire the source to present the pane
     $source.click(function (e) {
-      $pane.show()[0].scrollIntoView();
+      $pane.show();
+      pane.scrollIntoView();
+      pane.dispatchEvent(paneOpenEvent);
     });
 
     // Add the close button, and wire it.
@@ -37,6 +44,7 @@ $(function () {
     $el.click(function () {
       $pane.hide();
       $source[0].scrollIntoView({ block: "center" });
+      pane.dispatchEvent(paneCloseEvent);
       history.replaceState(null, null, " ");
     });
     $pane.append($el);


### PR DESCRIPTION
We discussed about:

 * [x] Pausing on close
 * [x] Playing on open
 * [ ] Smooth scrolling

The first two are implemented. See the new custom event for that.

Smooth scrolling using `el.scrollIntoView({ behavior: "smooth" });` does not smooth scroll, AFAICT.

So we would be left to choose an additional JavaScript library to handle the smooth scroll, only for the pane open/close sequence. We apparently can't rely on the browser to smooth scroll the site.

My personal experience with sites that scroll smoothly like that is that it's not ever needed, and most of the time feels wrong. For something I'm not entirely sure is needed.

I'll be leaving the decision for smooth scrolling to you, and I'll implement it if desired. Though it's back at the end of the queue for priorities for the time being. It would take a bunch of time to decide on the better library to use, time I prefer to use to implement the rest of the pages as MVPs.