### PR TITLE
Replace default.nix by shell.nix in screen cast for nix-shell

### DIFF
--- a/demos/example_3.scenario
+++ b/demos/example_3.scenario
@@ -2,9 +2,9 @@
 
 $ # You can also persist your development environment.
 $ # Here is a short example with python and nodejs:
-$ bat default.nix
+$ bat shell.nix
 ────────┬────────────────────────────────────────────────────────────────────
-        │ File: default.nix
+        │ File: shell.nix
 ────────┼──────────────────────────────────────────────────────────────────── 
     1   │ { pkgs ? import <nixpkgs> {} # here we import the nixpkgs package set
     2   │ }:
@@ -21,7 +21,7 @@ $ bat default.nix
    13   │   '';
    14   │ }
 ────────┴────────────────────────────────────────────────────────────────────
-$ # Pause the video to read and understand the default.nix
+$ # Pause the video to read and understand the shell.nix
 $ # To enter dev-environment simply run:
 $ nix-shell
 Start developing...


### PR DESCRIPTION
I think using `mkShell` in a `default.nix` is not something we should encourage.