### PR TITLE
Label buttons to the manuals with the manual names

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -69,7 +69,7 @@
           </ul>
         </li>
       </ul>
-      <a href="[%root%]manual/nix/stable" class="button">Read more</a>
+      <a href="[%root%]manual/nix/stable" class="button">Full Nix Manual</a>
     </li>
 
     <li>
@@ -144,7 +144,7 @@
         </li>
         <li><a href="[%root%]manual/nixpkgs/stable/#chap-submitting-changes">Contributing to Nixpkgs</a></li>
       </ul>
-      <a href="[%root%]manual/nixpkgs/stable" class="button">Read more</a>
+      <a href="[%root%]manual/nixpkgs/stable" class="button">Full Nixpkgs Manual</a>
     </li>
 
     <li>
@@ -163,7 +163,7 @@
         <li><a href="[%root%]manual/nixos/stable/#sec-nixos-tests">Writing NixOS Tests</a></li>
         <li><a href="[%root%]manual/nixos/stable/#sec-building-cd">Building Your Own NixOS CD</a></li>
       </ul>
-      <a href="[%root%]manual/nixos/stable" class="button">Read more</a>
+      <a href="[%root%]manual/nixos/stable" class="button">Full NixOS Manual</a>
     </li>
   </ul>
 </section>


### PR DESCRIPTION
This makes it clearer what the 3 'Read more...' buttons actually point to, and
that they are pointing to 3 different manuals.

Seems to fit fine on all zoom levels / window sizes I tried, and is helpful
especially in the mobile view where the 3 sections are actually below each
other rather than next to each other.