### PR TITLE
index: Rename "isolated" to "declarative" example

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -141,7 +141,7 @@
       [% WRAPPER exampleBlock demo="example_2" title="Multiple languages, one tool" %]
       [% END %]
 
-      [% WRAPPER exampleBlock demo="example_3" title="Isolated development environments" %]
+      [% WRAPPER exampleBlock demo="example_3" title="Declarative development environments" %]
       [% END %]
     </ul>
 


### PR DESCRIPTION
As there is no isolation and all of these shells are still able to wipe
all of your data we should probably not call them "isolated". They are
probably better described as `declarative` as that is what is happening
here.