### PR TITLE
Point link at schedule

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -37,7 +37,7 @@
       </ul>
     </div>
     <div class="action">
-      <a href="https://2020.nixcon.org/">Program</a>
+      <a href="https://2020.nixcon.org/#program">Program</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
The 2020.nixcon.org site now has a schedule widget. Point the link to that.