### PR TITLE
Remove 'variants'

### DIFF
--- a/site-styles/components/navbar.less
+++ b/site-styles/components/navbar.less
@@ -11,11 +11,8 @@ body > header {
   #fill-width();
   background: #theme.navbar[background];
 
-  // The light variant of the navbar needs a shadow.
-  & when (#theme.navbar[variant] = light) {
-    border-bottom: 1*@unit solid rgba(0, 0, 0, 0.2);
-    box-shadow: #theme.common[box-shadow];
-  }
+  border-bottom: 1*@unit solid rgba(0, 0, 0, 0.2);
+  box-shadow: #theme.common[box-shadow];
 
   // Ensure *everything* in the navbar fills it vertically.
   * {
@@ -88,12 +85,8 @@ body > header {
       @height: @_height,
     );
 
-    // Select according to the variant
-    &::before when (#theme.navbar[variant] = light) {
+    &::before {
       #svg.lambdaflake.color();
-    }
-    &::before when not (#theme.navbar[variant] = light) {
-      #svg.lambdaflake.white();
     }
 
 
@@ -106,12 +99,8 @@ body > header {
       @width: @_nixos_text_width,
       @height: @_height,
     );
-    // Select according to the variant
-    &::after when (#theme.navbar[variant] = light) {
+    &::after {
       #svg.nixos-text.black();
-    }
-    &::after when not (#theme.navbar[variant] = light) {
-      #svg.nixos-text.white();
     }
 
     // We can't rely on what `#text-replacement` gives us since we're doing it twice.

--- a/site-styles/configuration.less
+++ b/site-styles/configuration.less
@@ -10,15 +10,5 @@
   .navbar() {
     // Static navbar, true or false.
     static: false;
-
-    // Choose between light, dark, and darker
-    #theme.navbar.variant-light();
-    //#theme.navbar.variant-dark();
-    //#theme.navbar.variant-darker();
-  }
-  .font() {
-    // Choose between variant-A and variant-B
-    #theme.font.variant-A();
-    //#theme.font.variant-B();
   }
 }

--- a/site-styles/theme.less
+++ b/site-styles/theme.less
@@ -1,26 +1,14 @@
 // Describe the theme, mainly as variables in a Map.
-// Some namespaces will have variants defined, they have to be
-// configured in the `configuration.less` file.
 #theme() {
   .layout() {
   }
-  // The variant will be chosen in the configuration. The variant's
-  // keys will be merged with `#theme.font`.
   .font() {
     monospace: "Fira Mono", monospace;
 
-    .variant-A() {
-      primary: "Krub", sans-serif;
-      primary-weight: 400;
-      secondary: "Sora", serif;
-      secondary-weight: 700;
-    }
-    .variant-B() {
-      primary: "Open Sans", sans-serif;
-      primary-weight: 400;
-      secondary: "Zilla Slab", serif;
-      secondary-weight: 700;
-    }
+    primary: "Krub", sans-serif;
+    primary-weight: 400;
+    secondary: "Sora", serif;
+    secondary-weight: 700;
   }
 
   // Common rules shared across elements.
@@ -65,23 +53,8 @@
   .navbar() {
     height: 87*@unit;
 
-    .variant-darker() {
-      variant: darker;
-      background: #theme.color[blue-darker];
-      foreground: #theme.color[white];
-    }
-
-    .variant-dark() {
-      variant: dark;
-      background: #theme.color[blue-dark];
-      foreground: #theme.color[white];
-    }
-
-    .variant-light() {
-      variant: light;
-      background: #theme.color[background];
-      foreground: #theme.color[foreground];
-    }
+    background: #theme.color[background];
+    foreground: #theme.color[foreground];
   }
 
   .footer() {


### PR DESCRIPTION
In the sources there are 2 'variants' defined for fonts, and 3 for brightness
(light/dark/darker).

Do we plan to expose those at some point, or would it be a simpler to
get rid of them?

(the background is I'd like to look into self-hosting the fonts, but right now
it's not clear whether it makes sense to port all fonts or just the ones that
are used in 'variant A')