### PR TITLE
made the complete dependencies paragraph in features.tt a lot clearer for new users

### DIFF
--- a/features.tt
+++ b/features.tt
@@ -46,16 +46,15 @@
 
       <h2>Complete dependencies</h2>
 
-      <p>Nix helps you make sure that package dependency specifications are
+      <p>When you’re making a package for a package management system, like RPM,
+        you are supposed to declare its dependencies, but you can't easily
+        guarantee that your dependency declaration is complete. If you forget
+        a dependency, that you have separately installed on your machine, then
+        the component may build and work correctly on <em>your</em> machine,
+        but failing on the end user's machine.</p>
+
+      <p>Nix ensures that that package dependency specifications are
         complete.</p>
-      
-      <p>When you’re making a package for a package
-        management system like RPM, you are supposed to declare its dependencies,
-        but you can't easily guarantee that your dependency declaration is complete.
-        If you forget a dependency, then the
-        component may build and work correctly on <em>your</em> machine, if
-        you already have the dependency installed, while failing on the end user's
-        machine, if they don't.</p>
 
       <p>Under Nix, a build process will only find resources that have been
         declared explicitly as dependencies. There's no way it can build until
@@ -63,10 +62,7 @@
         you've provided a complete declaration.</p>
 
       <p>Once a build is complete, ongoing runtime dependencies are detected
-        automatically by scanning the package's build result files for the hash parts
-        of Nix store paths (such as <tt>r8vvq9kq…</tt>). This may sound risky,
-        but it works extremely well.</p>
-
+        automatically</p>
 
       <h2>Multi-user support</h2>
 

--- a/features.tt
+++ b/features.tt
@@ -47,26 +47,25 @@
       <h2>Complete dependencies</h2>
 
       <p>Nix helps you make sure that package dependency specifications are
-        complete. In general, when you’re making a package for a package
-        management system like RPM, you have to specify for each package what
-        its dependencies are, but there are no guarantees that this
-        specification is complete. If you forget a dependency, then the
-        component will build and work correctly on <em>your</em> machine if
-        you have the dependency installed, but not on the end user's machine
-        if it's not there.</p>
+        complete.</p>
+      
+      <p>When you’re making a package for a package
+        management system like RPM, you are supposed to declare its dependencies,
+        but you can't easily guarantee that your dependency declaration is complete.
+        If you forget a dependency, then the
+        component may build and work correctly on <em>your</em> machine, if
+        you already have the dependency installed, while failing on the end user's
+        machine, if they don't.</p>
 
-      <p>Since Nix on the other hand doesn’t install packages in “global”
-        locations like <tt>/usr/bin</tt> but in package-specific directories,
-        the risk of incomplete dependencies is greatly reduced. This is
-        because tools such as compilers don’t search in per-packages
-        directories such as
-        <tt>/nix/store/5lbfaxb722zp…-openssl-0.9.8d/include</tt>, so if a
-        package builds correctly on your system, this is because you specified
-        the dependency explicitly.</p>
+      <p>Under Nix, a build process will only find resources that have been
+        declared explicitly as dependencies. There's no way it can build until
+        everything it needs has been correctly declared. If it builds, you will know
+        you've provided a complete declaration.</p>
 
-      <p>Runtime dependencies are found by scanning binaries for the hash
-        parts of Nix store paths (such as <tt>r8vvq9kq…</tt>). This may sound
-        risky, but it works extremely well.</p>
+      <p>Once a build is complete, ongoing runtime dependencies are detected
+        automatically by scanning the package's build result files for the hash parts
+        of Nix store paths (such as <tt>r8vvq9kq…</tt>). This may sound risky,
+        but it works extremely well.</p>
 
 
       <h2>Multi-user support</h2>


### PR DESCRIPTION
When trying to learn how nix works through the features page, I had a lot of trouble understanding this section. We discussed it here https://discourse.nixos.org/t/site-intro-to-nixs-repeatable-builds-point-has-some-clarity-issues/9154/4 , and eventually things were explained to me. Accordingly, I have changed the section so that it will be more clear for new users.

In short, saying "compilers don’t search in per-packages
        directories such as
        <tt>/nix/store/5lbfaxb722zp…-openssl-0.9.8d/include</tt>,"
Is very confusing for a new user, because they are trying to understand how compilers actually do find their way into nix's store when they're allowed to, and this comes across as if it's saying that they don't. It is in fact a regular occurrence for compilers to "search" those directories, and they need to see this acknowledged, so it's very hard for them to find the intended meaning.

"Runtime dependencies are found by scanning binaries" is also somewhat confusing, as the result files of a build might not always be binaries. A new user would be led to ask "why just the binaries?"