### PR TITLE
Rename Nix cookbook -> nix.dev

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -180,7 +180,7 @@
           the
           more formal documents.</li>
         <li><a href="https://nixos.wiki">Wiki</a> — A user-maintained wiki for Nix and NixOS.</li>
-        <li><a href="https://nix-cookbook.readthedocs.io">Nix cookbook</a> — Nix Community Cookbook presents topical,
+        <li><a href="https://nix.dev">nix.dev</a> — nix.dev presents topical,
           practical ways of using Nix package manager ecosystem.</li>
       </ul>
     </li>


### PR DESCRIPTION
afaict https://nix-cookbook.readthedocs.io just redirects to nix.dev @domenkozar 