### PR TITLE
learn: add link to the release notes

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -162,6 +162,7 @@
         <li><a href="[%root%]manual/nixos/stable/#sec-writing-documentation">Writing NixOS Documentation</a></li>
         <li><a href="[%root%]manual/nixos/stable/#sec-nixos-tests">Writing NixOS Tests</a></li>
         <li><a href="[%root%]manual/nixos/stable/#sec-building-cd">Building Your Own NixOS CD</a></li>
+        <li><a href="[%root%]manual/nixos/stable/release-notes.html">Release Notes</a></li>
       </ul>
       <a href="[%root%]manual/nixos/stable" class="button">Full NixOS Manual</a>
     </li>


### PR DESCRIPTION
It *should* be frequently accessed content for everyone upgrading a
NixOS machine. This make it a bit more discoverable from the learn page.