### PR TITLE
site-styles: Fix asciinema breaking width by removing aspect ratio code

### DIFF
--- a/site-styles/components/asciinema.less
+++ b/site-styles/components/asciinema.less
@@ -18,7 +18,7 @@
 
       // vertical (portrait) and square aspect ratio
       // In that case we set it as a fraction of the width.
-      @media screen and (max-aspect-ratio: ~"1/1") and (max-width: (@screen-sm-max)) {
+      @media screen and (max-width: (@screen-sm-max)) {
         font-size: 1.65vw;
       }
     }


### PR DESCRIPTION
fixes #597 

> The reason there was that aspect ratio thing there was to, if I remember
> right, make the whole player fit in the height of a side-ways mobile
> device.
> 
> Though I think I must have forgotten to finish implementing this, as
> instead it just resolved to using the default font sizes.
> 
> Rather, let's do what works fine for every other sizes: a ratio of the
> device width.

— @samueldr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nixos/nixos-homepage/637)
<!-- Reviewable:end -->
