### PR TITLE
Revert "Revert "NixOS Download: recommend GNOME""

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -110,13 +110,13 @@
 
         <ul class="download-buttons">
           <li>
-            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso">Download (Plasma Desktop, 64bit)</a>
-            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso.sha256">(SHA-256)</a>
+            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso">Download (GNOME, 64bit)</a>
+            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso.sha256">(SHA-256)</a>
             <span class="label -success">Recommended for most users</span>
           </li>
           <li>
-            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso">Download (GNOME, 64bit)</a>
-            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso.sha256">(SHA-256)</a>
+            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso">Download (Plasma Desktop, 64bit)</a>
+            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso.sha256">(SHA-256)</a>
           </li>
         </ul>
 


### PR DESCRIPTION
Reverts NixOS/nixos-homepage#642

From that PR:

> The GNOME ISO correctly detects and configures HiDPI scaling.
> More, it supports changing the scale. The Plasma Desktop ISO
> doesn't detect and configure the scale automatically, and doesn't
> allow you to change it without restarting. This makes the GNOME
> ISO significantly more accessible for users on laptops with HiDPI
> displays.

Bringing this back to the table. After discussing it with @worldofpeace, they +1'd. Maybe let's hear from @jonringer too.