### PR TITLE
Fix publication dates in xml

### DIFF
--- a/news.xml
+++ b/news.xml
@@ -227,7 +227,7 @@
   </item>
 
   <item>
-    <pubDate>Wed, Oct 09 2019 00:00:00 GMT</pubDate>
+    <pubDate>Wed, 09 Oct 2019 00:00:00 GMT</pubDate>
     <title>
       NixOS 19.09 released
     </title>
@@ -246,7 +246,7 @@
   </item>
 
   <item>
-    <pubDate>Wed, Apr 10 2019 00:00:00 GMT</pubDate>
+    <pubDate>Wed, 10 Apr 2019 00:00:00 GMT</pubDate>
     <title>
       NixOS 19.03 released
     </title>
@@ -265,7 +265,7 @@
   </item>
 
   <item>
-    <pubDate>Sat, Oct 06 2018 00:00:00 GMT</pubDate>
+    <pubDate>Sat, 06 Oct 2018 00:00:00 GMT</pubDate>
     <title>
       NixOS 18.09 released
     </title>
@@ -285,7 +285,7 @@
   </item>
 
   <item>
-    <pubDate>Thu, Oct 04 2018 00:00:00 GMT</pubDate>
+    <pubDate>Thu, 04 Oct 2018 00:00:00 GMT</pubDate>
     <title>
       Fastly supports NixOS
     </title>


### PR DESCRIPTION
A few items in the news.xml file have misformated dates. this breaks
the XML feeds.

see all pubdates via grep -i pubdate news.xml:

```
<pubDate>Tue, 27 Oct 2020 07:00:00 GMT</pubDate>
<pubDate>Mon, 20 Apr 2020 23:27:10 GMT</pubDate>
<pubDate>Wed, Oct 09 2019 00:00:00 GMT</pubDate>
<pubDate>Wed, Apr 10 2019 00:00:00 GMT</pubDate>
<pubDate>Sat, Oct 06 2018 00:00:00 GMT</pubDate>
<pubDate>Thu, Oct 04 2018 00:00:00 GMT</pubDate>
<pubDate>Sun, 02 Sep 2018 00:00:00 GMT</pubDate>
```

feedreader failures:
```
(feedreader:15369): feedreader-WARNING **: 08:39:15.719: RFC 822 date parser failed to parse Thu, Oct 04 2018 00:00:00 GMT. Falling back to DateTime.now()
```

![Screenshot from 2021-02-08 08-44-02](https://user-images.githubusercontent.com/1443459/107253101-d4e56800-69ea-11eb-94ca-56f808950cd3.png)