### PR TITLE
Copyright notice: NixOS -> NixOS contributors

### DIFF
--- a/layout.tt
+++ b/layout.tt
@@ -120,7 +120,7 @@ BLOCK navigationLink %]
           <h4>NixOS</h4>
           <div>
             <span>
-              Copyright © [% date.format(date.now, '%Y') %] NixOS
+              Copyright © [% date.format(date.now, '%Y') %] NixOS contributors
             </span>
             <a href="https://github.com/NixOS/nixos-homepage/blob/master/LICENSES/CC-BY-SA-4.0.txt">
               <abbr title="Creative Commons Attribution Share Alike 4.0 International">


### PR DESCRIPTION
This used to be a rather vague statement, because "NixOS" is not
the name of a person or legal entity.
Nobody has signed away their copyright, so it remains with the
individual contributors.
This is not legal advice.