### PR TITLE
styling: add styling for governance-description

### DIFF
--- a/site-styles/pages/community.less
+++ b/site-styles/pages/community.less
@@ -559,6 +559,10 @@
   }
 }
 
+.governance-description {
+  .generic-layout();
+}
+
 .governance-team {
   .generic-layout();
 


### PR DESCRIPTION
Fix #682 by adding styling for `governance-description`.
This shall affect every pages that lies under `community/teams`.

![](https://user-images.githubusercontent.com/20080233/111028699-34dc8d80-8433-11eb-8628-7271a7fcabaf.png)
