### PR TITLE
Montpellier moved from Meetup to Mobilizon

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -176,7 +176,7 @@
         <li><a href="https://www.meetup.com/Greater-Copenhagen-NixOS-User-Group">Copenhagen (Denmark)</a></li>
         <li><a href="https://www.meetup.com/Suisse-Romande-NixOS-User-Group/">Lausanne (Switzerland)</a></li>
         <li><a href="https://www.meetup.com/NixOS-London/">London (United Kingdom)</a></li>
-        <li><a href="https://www.meetup.com/Meetup-NixOS-Montpellier/">Montpellier (France)</a></li>
+        <li><a href="https://mobilizon.fr/@nix-mtp">Montpellier (France)</a></li>
         <li><a href="http://www.meetup.com/Munich-NixOS-Meetup/">Munich (Germany)</a></li>
         <li><a href="https://www.meetup.com/Oslo-NixOS-User-Group/">Oslo (Norway)</a></li>
         <li><a href="https://blog.shackspace.de/?p=5829">Stuttgart (Germany)</a></li>


### PR DESCRIPTION
We've closed `Meetup-NixOS-Montpellier` group on Meetup.com (not open source, too expensive…). The same group is now "NixOS Montpellier" (alias "nix-mtp") on mobilizon.fr.