### PR TITLE
index.tt: add emails of Foundation board members

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -268,9 +268,9 @@
       <h2>NixOS Foundation</h2>
       <h3>Board members:</h3>
       <ul>
-        <li><a href="mailto:edolstra@gmail.com">Eelco Dolstra</a> - Chairman</li>
-        <li><a href="mailto:info@tjaldur.nl">Armijn Hemel</a> - Secretary</li>
-        <li><a href="mailto:rob.vermaas@gmail.com>Rob Vermaas</a> - Treasurer</li>
+        <li>Eelco Dolstra - Chairman</li>
+        <li>Armijn Hemel - Secretary</li>
+        <li>Rob Vermaas - Treasurer</li>
       </ul>
     </div>
     <div>
@@ -296,6 +296,7 @@
       <p>The NixOS Foundation is a registered non-profit organisation at the Chamber of
         commerce (Kamer van Koophandel) in Utrecht, The Netherlands. The KvK number is 63520583.
       </p>
+      <p>You can contact the foundation by writing an email to <a href="mailto:foundation@nixos.org">foundation@nixos.org</a>.</p>
     </div>
   </div>
 </section>

--- a/community/index.tt
+++ b/community/index.tt
@@ -268,9 +268,9 @@
       <h2>NixOS Foundation</h2>
       <h3>Board members:</h3>
       <ul>
-        <li>Eelco Dolstra - Chairman</li>
-        <li>Armijn Hemel - Secretary</li>
-        <li>Rob Vermaas - Treasurer</li>
+        <li><a href="mailto:edolstra@gmail.com">Eelco Dolstra</a> - Chairman</li>
+        <li><a href="mailto:info@tjaldur.nl">Armijn Hemel</a> - Secretary</li>
+        <li><a href="mailto:rob.vermaas@gmail.com>Rob Vermaas</a> - Treasurer</li>
       </ul>
     </div>
     <div>


### PR DESCRIPTION
To make it easier to contact them.

Ideally though, the foundation would have its own email address.