### PR TITLE
update-blog: add cchardet dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@ rec {
         mkPyScript (with pkgs.python3Packages; [ click toml ]) "shuffle-commercial-providers";
 
       update_blog =
-        mkPyScript (with pkgs.python3Packages; [ aiohttp click feedparser ]) "update-blog";
+        mkPyScript (with pkgs.python3Packages; [ aiohttp click feedparser cchardet ]) "update-blog";
 
     in rec {
       defaultPackage."${system}" = packages."${system}".homepage;


### PR DESCRIPTION
aiohttp will use cchardet to determine the charset of the page it
retrieves if it's available and isn't specified in the Content-Type
header. In the case of some of the sources it isn't specified, which
leads to problems when parsing them.

This fixes the failed updates - https://github.com/NixOS/nixos-homepage/runs/2535903129?check_suite_focus=true.