### PR TITLE
Tell crawlers that the canonical url for guides is at nix.dev

### DIFF
--- a/scripts/copy-nix-dev-tutorials.sh
+++ b/scripts/copy-nix-dev-tutorials.sh
@@ -35,8 +35,10 @@ for page in "${pages[@]}"; do
     | sed 's|<a class="reference internal" href="../glossary.html#term-reproducible"><span class="xref std std-term">reproducible</span></a>|reproducible|g' \
     | sed 's|../reference/pinning-nixpkgs.html#ref-pinning-nixpkgs|towards-reproducibility-pinning-nixpkgs.html|g' \
       > "$temp"
+  
+  echo "[% WRAPPER atHead %] <link rel=\"canonical\" href=\"https://nix.dev/$page\" /> [% END %]" > $target
 
-  echo "[% WRAPPER layout.tt title=\"Guides - $title\" handlesLayout=1 %]" > $target
+  echo "[% WRAPPER layout.tt title=\"Guides - $title\" handlesLayout=1 %]" >> $target
   echo "<div class=\"page-title\">" >> $target
   echo "  <div>" >> $target
   echo "    <a href=\"[% root%]learn.html#learn-guides\">Learn</a>" >> $target


### PR DESCRIPTION
Otherwise, search engines deemphasize both sites as they duplicate content.