### PR TITLE
Add CORS policy for matrix client endpoint

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -430,3 +430,8 @@
   to = "/css/nixos-site.css"
   status = 302
   force = true
+
+[[headers]]
+  for = "/.well-known/matrix/client"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Untested, but based on https://github.com/NixOS/nixos-homepage/pull/709 and https://docs.netlify.com/routing/headers/.