### PR TITLE
Add og:image to your layout

### DIFF
--- a/layout.tt
+++ b/layout.tt
@@ -32,6 +32,7 @@ BLOCK navigationLink %]
   <link rel="stylesheet" href="[% root %]styles/index.css" type="text/css" />
 
   <link rel="shortcut icon" type="image/png" href="/favicon.png" />
+  <meta property="og:image" content="/logo/nixos-lores.png" />
   <meta name="google-site-verification" content="ir-07nYvo3u3x_VmkTO1wCfYJ8uC-SrVBGR7hZgqPSE" />
 
   [%# This has to happen ASAP, even before jQuery is initialized. %]


### PR DESCRIPTION
Previously the first picture would be shown instead of a NixOS related
image when a NixOS.org website is referred to from Matrix, Discourse
etc..