### PR TITLE
Remove freenode links

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -23,15 +23,6 @@
       <a href="https://discourse.nixos.org/">Discourse Forum</a>
     </div>
     <div>
-      <h2>Chat</h2>
-      <p>Another place to get in contact with other users is the official IRC
-        channel:</p>
-      <p><a href="irc://irc.freenode.net/#nixos">#nixos</a> on the <a href="https://freenode.net/">freenode network</a>
-        (<a href="https://logs.nix.samueldr.com/nixos/">logs</a> are
-        available)</p>
-      <a href="https://webchat.freenode.net/#nixos">Open Webchat</a>
-    </div>
-    <div>
       <h2>Other Platforms</h2>
       <p>The community is also active on other platforms.</p>
       <ul>

--- a/community/teams/security.tt
+++ b/community/teams/security.tt
@@ -77,7 +77,7 @@
     <li>The issues tagged "Security" on <a
         href="https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%221.severity%3A+security%22">GitHub/NixOS</a>
     </li>
-    <li>The #nixos-security IRC channel on FreeNode
+    <li>The <a href="https://app.element.io/#/room/#security:nixos.org">#security</a> room on Matrix
     </li>
     <li>The NixOS security <a href="https://discourse.nixos.org/c/dev/security">discourse</a>
     </li>

--- a/community/teams/security.tt
+++ b/community/teams/security.tt
@@ -77,7 +77,7 @@
     <li>The issues tagged "Security" on <a
         href="https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%221.severity%3A+security%22">GitHub/NixOS</a>
     </li>
-    <li>The <a href="https://app.element.io/#/room/#security:nixos.org">#security</a> room on Matrix
+    <li>The <a href="https://matrix.to/#/#security:nixos.org">#security:nixos.org</a> room on Matrix
     </li>
     <li>The NixOS security <a href="https://discourse.nixos.org/c/dev/security">discourse</a>
     </li>

--- a/layout.tt
+++ b/layout.tt
@@ -96,7 +96,6 @@ BLOCK navigationLink %]
           <h4>Get in Touch</h4>
           <ul>
             <li><a href="https://discourse.nixos.org/">Forum</a></li>
-            <li><a href="https://webchat.freenode.net/#nixos">Chat</a></li>
             <li><a href="[% root %]community/commercial-support.html">Commercial support</a></li>
           </ul>
         </section>


### PR DESCRIPTION
This removes the links to the abandoned `#nixos` channel on Freenode, and replaces the link to the `#nixos-security` by the corresponding Matrix room.

There are still some references to the `#nixos-marketing` channel, but we don't have an equivalent Matrix room yet.