### PR TITLE
Add links to Matrix

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -16,6 +16,12 @@
   <h1>Where to talk?</h1>
   <div>
     <div>
+      <h2>Chat</h2>
+      <p>Real-time help, development chat, and off-topic community discussion
+        takes place on Matrix.</p>
+      <a href="https://matrix.to/#/#community:nixos.org">NixOS Matrix Space</a>
+    </div>
+    <div>
       <h2>Forum</h2>
       <p>The official forum is the right place to get help from other users and
         discuss the development of the projects. There are also Announcements,

--- a/layout.tt
+++ b/layout.tt
@@ -96,6 +96,7 @@ BLOCK navigationLink %]
           <h4>Get in Touch</h4>
           <ul>
             <li><a href="https://discourse.nixos.org/">Forum</a></li>
+            <li><a href="https://matrix.to/#/#community:nixos.org">Matrix Chat</a></li>
             <li><a href="[% root %]community/commercial-support.html">Commercial support</a></li>
           </ul>
         </section>


### PR DESCRIPTION
ea454f3 ("Remove references to abandoned #nixos channel") removed the
references to Freenode, but didn't replace them with anything, even
though we didn't stop using live chat -- we moved to Matrix.

Here, I've re-added links to Matrix where we used to link to Freenode.
