### PR TITLE
styling: fix width of commercial support logos

### DIFF
--- a/site-styles/pages/community.less
+++ b/site-styles/pages/community.less
@@ -629,6 +629,7 @@
             left: 0;
             right: 0;
             position: absolute;
+            object-fit: contain;
           }
         }
       }


### PR DESCRIPTION
before: ![image](https://user-images.githubusercontent.com/1229027/125860704-63bedfa4-1e9f-4257-97b7-591c10463f24.png)

after: 
![image](https://user-images.githubusercontent.com/1229027/125861014-d61fcd06-0082-42ca-aaea-c0b4fccb7865.png)
