### PR TITLE
download: add working gpg keyserver

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -36,7 +36,7 @@
         <pre class="terminal-console">
 <span cls="shell-prompt">$ </span>curl -o install-nix-[%latestNixVersion%] https://releases.nixos.org/nix/nix-[%latestNixVersion%]/install
 <span cls="shell-prompt">$ </span>curl -o install-nix-[%latestNixVersion%].asc https://releases.nixos.org/nix/nix-[%latestNixVersion%]/install.asc
-<span cls="shell-prompt">$ </span>gpg2 --recv-keys B541D55301270E0BCF15CA5D8170B4726D7198DE
+<span cls="shell-prompt">$ </span>gpg2 --keyserver keyserver.ubuntu.com --recv-keys B541D55301270E0BCF15CA5D8170B4726D7198DE
 <span cls="shell-prompt">$ </span>gpg2 --verify ./install-nix-[%latestNixVersion%].asc
 <span cls="shell-prompt">$ </span>sh ./install-nix-[%latestNixVersion%]</pre>
         <p>


### PR DESCRIPTION
Not all gnupg server seem to have a working uid along with the key.
The ubuntu one seems to work.