### PR TITLE
removed nixcloud.io (out of business)

### DIFF
--- a/community/commercial-support.html.in
+++ b/community/commercial-support.html.in
@@ -87,18 +87,6 @@ consulting, and build and deployment engineering services.
     </li>
 
     <li>
-      <a href="https://nixcloud.io/">
-        <div>
-          <img alt="nixcloud" src="/community/commercial-support-logos/nixcloud.png" />
-        </div>
-        <h2>nixcloud</h2>
-        <ul><li>Tübingen, Germany</li></ul>
-        Platform for Nix based projects and services.
-
-      </a>
-    </li>
-
-    <li>
       <a href="https://immutablesolutions.com/">
         <div>
           <img alt="Immutable Solutions" src="/community/commercial-support-logos/immutable-solutions.png" />

--- a/community/commercial-support.toml
+++ b/community/commercial-support.toml
@@ -59,15 +59,6 @@ We are Mayflower. We build infrastructure. Declarative &amp; reproducible.
 """
 
 [[commercial-provider]]
-name = "nixcloud"
-url = "https://nixcloud.io/"
-locations = ["Tübingen, Germany"]
-logo = "/community/commercial-support-logos/nixcloud.png"
-description = """
-Platform for Nix based projects and services.
-"""
-
-[[commercial-provider]]
 name = "NumTide Ltd"
 url = "https://www.numtide.com/"
 locations = ["London, UK"]


### PR DESCRIPTION
removing nixcloud.io from the commercial list. unfortunately nixcloud.io is out of business and does no longer exist as a company.