### PR TITLE
Add the NixOS Foundation's statement of inclusion

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -10,6 +10,13 @@
 <section class="community-description">
   <p>Nix and NixOS are developed and used by a diverse and welcoming community
     from all around the world.</p>
+  <p>The NixOS Foundation aims to promote participation without regard to gender,
+    sexual orientation, disability, ethnicity, age, or similar personal
+    characteristics.</p>
+  <p>We want to strive to create and foster community by providing an
+    intentionally welcoming and safe environment where all feel valued and cared
+    for, and where all are given opportunity to participate meaningfully. The
+    Foundation will work with the community in service of this goal.</p>
 </section>
 
 <section class="community-communication">

--- a/site-styles/pages/community.less
+++ b/site-styles/pages/community.less
@@ -1,6 +1,10 @@
 .community-description {
   .generic-layout();
-  .lead();
+
+  // Only apply `lead` to the first paragraph of the community statement.
+  & > :first-child {
+	.lead();
+  }
 }
 
 .community-banner {


### PR DESCRIPTION
Established May 7 this year with Armijn, Rob, and Eelco. At the time,
it was primarily shared on Twitter:

https://twitter.com/grhmc/status/1390775249424338944

I should have added it to the website then, but now is a good time
too.