### PR TITLE
Redirect old bootstrap tarball URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -299,6 +299,12 @@
   force = true
 
 [[redirects]]
+  from = "/tarballs/*"
+  to = "https://tarballs.nixos.org/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/channels/*"
   to = "https://channels.nixos.org/:splat"
   status = 302


### PR DESCRIPTION
When trying to build a very old version of Nixpkgs, from 2009, I wasn't able to download the bootstrap tools.  It was trying to download them from <http://tarballs.nixos.org/stdenv-linux/x86_64/r13932/bootstrap-tools.cpio.bz2>.

Now, the curl in this ancient Nixpkgs doesn't support https, but if there'd been a redirect, at least as a user I'd have been able to nix-prefetch-url it to add it to the store manually, instead of guessing where it might have moved.
