### PR TITLE
commercial-support: Drop accidentally committed devdocs

### DIFF
--- a/community/commercial-support.html.in
+++ b/community/commercial-support.html.in
@@ -1,13 +1,3 @@
-
-  To start developing run:
-      serve
-
-  and go to the following URL in your browser:
-      https://127.0.0.1:8000/
-
-  It will rebuild the website on each change.
-
-
     <li>
       <a href="https://www.fivebinaries.com/">
         <div>


### PR DESCRIPTION
In d0ac4b15 parts of the shellHook that describe how to
hack on the website were accidentally committed as part of the
commercial-support page.

Fixes: #750
