### PR TITLE
Fix broken Nix manual links

### DIFF
--- a/blog/announcements.xml
+++ b/blog/announcements.xml
@@ -426,7 +426,7 @@
     </title>
     <description>
       <a href="/download.html#download-nix">Nix 2.1</a>
-      has been released. See the <a href="/manual/nix/stable#ssec-relnotes-2.1">release
+      has been released. See the <a href="/manual/nix/stable/release-notes/rl-2.1.html">release
         notes</a> for a list of changes and new features.
     </description>
   </item>
@@ -483,7 +483,7 @@
     </title>
     <description>
       <a href="/download.html#download-nix">Nix 2.0</a>
-      has been released. See the <a href="/manual/nix/stable#ssec-relnotes-2.0">release
+      has been released. See the <a href="/manual/nix/stable/release-notes/rl-2.0.html">release
         notes</a> for a list of changes and new features.
     </description>
   </item>
@@ -608,7 +608,7 @@
     </title>
     <description>
       <a href="/download.html#download-nix">Nix 1.11</a>
-      has been released. See the <a href="/manual/nix/stable#ssec-relnotes-1.11">release
+      has been released. See the <a href="/manual/nix/stable/release-notes/rl-1.11.html">release
         notes</a> for a list of changes and new features.
     </description>
   </item>
@@ -638,7 +638,7 @@
     </title>
     <description>
       <a href="/download.html#download-nix">Nix 1.10</a>
-      has been released. See the <a href="/manual/nix/stable#ssec-relnotes-1.10">release
+      has been released. See the <a href="/manual/nix/stable/release-notes/rl-1.10.html">release
         notes</a> for a list of changes and new features.
     </description>
   </item>
@@ -682,7 +682,7 @@
     </title>
     <description>
       <a href="https://hydra.nixos.org/release/nix/nix-1.9">Nix 1.9</a>
-      has been released. See the <a href="https://web.archive.org/web/20200423231710/https://releases.nixos.org/nix/nix-1.9/manual/#ssec-relnotes-1.9">release
+      has been released. See the <a href="/manual/nix/stable/release-notes/rl-1.9.html">release
         notes</a> for a list of changes and new features.
     </description>
   </item>
@@ -713,7 +713,7 @@
     </title>
     <description>
       <a href="https://hydra.nixos.org/release/nix/nix-1.8">Nix 1.8</a>
-      has been released. See the <a href="https://web.archive.org/web/20200423231710/https://releases.nixos.org/nix/nix-1.8/manual/#ssec-relnotes-1.8">release
+      has been released. See the <a href="/manual/nix/stable/release-notes/rl-1.8.html">release
         notes</a> for a list of changes and new features.
     </description>
   </item>
@@ -772,7 +772,7 @@
     <description>
       <a href="https://hydra.nixos.org/release/nix/nix-1.7">Nix 1.7</a>
       has been released. See the <a
-        href="https://web.archive.org/web/20170723084043/https://releases.nixos.org/nix/nix-1.7/manual/#ssec-relnotes-1.7">release
+        href="/manual/nix/stable/release-notes/rl-1.7.html">release
         notes</a> for a list of new features.
     </description>
   </item>
@@ -862,7 +862,7 @@ $ nix-store -qR /run/current-system | grep openssl
       <a href="https://hydra.nixos.org/release/nix/nix-1.6.1">Nix
         1.6.1</a> has been released. This is primarily a bug fix
       release but has some minor new features. See the <a
-        href="https://web.archive.org/web/20200916201737//manual/nix/stable/#ssec-relnotes-1.6.1">release
+        href="/manual/nix/stable/release-notes/rl-1.6.1.html">release
         notes</a> for details.
     </description>
   </item>

--- a/learn.tt
+++ b/learn.tt
@@ -74,34 +74,34 @@
           Packages that Nix can build are defined with the Nix Expression Language.
         </p>
         <ul>
-          <li><a href="[%root%]manual/nix/stable/#ch-installing-binary">Installation</a></li>
-          <li><a href="[%root%]manual/nix/stable/#ch-basic-package-mgmt">Basic package management</a></li>
-          <li><a href="[%root%]manual/nix/stable/#sec-channels">What is a channel?</a></li>
+          <li><a href="[%root%]manual/nix/stable/installation/installing-binary.html">Installation</a></li>
+          <li><a href="[%root%]manual/nix/stable/package-management/basic-package-mgmt.html">Basic package management</a></li>
+          <li><a href="[%root%]manual/nix/stable/package-management/channels.html">What is a channel?</a></li>
           <li>
             Main command line tools:
             <ul>
-              <li><a href="[%root%]manual/nix/stable/#sec-nix-env">nix-env</a> — manipulate or query Nix user
+              <li><a href="[%root%]manual/nix/stable/command-ref/nix-env.html">nix-env</a> — manipulate or query Nix user
                 environments
               </li>
-              <li><a href="[%root%]manual/nix/stable/#sec-nix-build">nix-build</a> — build a Nix expression</li>
-              <li><a href="[%root%]manual/nix/stable/#sec-nix-shell">nix-shell</a> — start an interactive shell based on
+              <li><a href="[%root%]manual/nix/stable/command-ref/nix-build.html">nix-build</a> — build a Nix expression</li>
+              <li><a href="[%root%]manual/nix/stable/command-ref/nix-shell.html">nix-shell</a> — start an interactive shell based on
                 a
                 Nix
                 expression</li>
-              <li><a href="[%root%]manual/nix/stable/#sec-nix-store">nix-store</a> — manipulate or query the Nix store
+              <li><a href="[%root%]manual/nix/stable/command-ref/nix-store.html">nix-store</a> — manipulate or query the Nix store
               </li>
             </ul>
           </li>
           <li>
-            <a href="[%root%]manual/nix/stable/#ch-expression-language">Nix expression language</a>
+            <a href="[%root%]manual/nix/stable/expressions/expression-language.html">Nix expression language</a>
             <ul>
-              <li><a href="[%root%]manual/nix/stable/#ssec-builtins">Built-in functions</a></li>
+              <li><a href="[%root%]manual/nix/stable/expressions/builtins.html">Built-in functions</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-functions-library">Nixpkgs Library Functions</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-debug">Debugging Nix Expressions</a></li>
             </ul>
           </li>
         </ul>
-        <a href="[%root%]manual/nix/stable">Full Nix Manual</a>
+        <a href="[%root%]manual/nix/stable/">Full Nix Manual</a>
       </div>
     </li>
 


### PR DESCRIPTION
Including the archive links from https://github.com/NixOS/nixos-homepage/commit/412c3eb79e365540dcec71970f1b69c54f84dffd

Used `linkchecker --config=<(echo '[AnchorCheck]') --check-extern https://nixos.org/` to find the issues but it is super noisy (anchorcheck is somewhat broken and GitHub kept giving me 503 errors).

Fixes: https://github.com/NixOS/nixos-homepage/issues/756