### PR TITLE
scripts/update-blog.py: Pass response as raw bytes to feedparser

### DIFF
--- a/scripts/update-blog.py
+++ b/scripts/update-blog.py
@@ -122,7 +122,7 @@ async def fetch_feed(session, feed_id, feed):
     if isinstance(feed, Feed):
         click.echo(f"     Fetching {feed.title} via `{feed.url}`")
         async with session.get(feed.rss_url) as response:
-            content = await response.text()
+            content = await response.read()
             click.echo(f"      Fetched {feed.title}")
             return (feed_id, feedparser.parse(content))
     elif isinstance(feed, Categories):


### PR DESCRIPTION
Currently external pages with umlauts are parsed erroneouly similar to the following: `"Höse".encode("utf8").decode("cp1252")` -> `'HÃ¶se'`.

Reported on Matrix by @samueldr.