### PR TITLE
manual: Prevent the stylesheet from eating the admonition contents

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1619640096,
-        "narHash": "sha256-gMnaDRsfLVmnBCoXwgjGJZmqBd/XUGpdZY5UkUEroEM=",
+        "lastModified": 1638915714,
+        "narHash": "sha256-w5qIrnLiaWm/YhIEpgwQrhr3dZgnBP//a7ueDSm63ho=",
         "owner": "NixOS",
         "repo": "nixos-common-styles",
-        "rev": "d5787c2a12922059712862e62ca2a324062b2954",
+        "rev": "fa19c7b909ae283851b1b580b1583f4a6375be29",
         "type": "github"
       },
       "original": {

--- a/scripts/bootstrapify-docbook.xsl
+++ b/scripts/bootstrapify-docbook.xsl
@@ -139,12 +139,24 @@
   <xsl:template name="alert-class">
     <xsl:param name="admonition-type"/>
     <xsl:choose>
+      <xsl:when test="$admonition-type = 'caution'">
+        <xsl:value-of select="'alert-danger'"/>
+      </xsl:when>
+      <xsl:when test="$admonition-type = 'danger'">
+        <xsl:value-of select="'alert-danger'"/>
+      </xsl:when>
+      <xsl:when test="$admonition-type = 'important'">
+        <xsl:value-of select="'alert-warning'"/>
+      </xsl:when>
       <xsl:when test="$admonition-type = 'note'">
         <xsl:value-of select="'alert-info'"/>
       </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="concat('alert-', $admonition-type)"/>
-      </xsl:otherwise>
+      <xsl:when test="$admonition-type = 'tip'">
+        <xsl:value-of select="'alert-info'"/>
+      </xsl:when>
+      <xsl:when test="$admonition-type = 'warning'">
+        <xsl:value-of select="'alert-warning'"/>
+      </xsl:when>
     </xsl:choose>
   </xsl:template>
 
@@ -158,7 +170,7 @@
 
     in which case we turn it into a single line as prefered by Bootstrap.
   -->
-  <xsl:template match="x:div[(@class='warning' or @class='note') and count(*) = 2]">
+  <xsl:template match="x:div[(@class='caution' or @class = 'danger' or @class = 'important' or @class = 'note' or @class = 'tip' or @class = 'warning') and count(*) = 2]">
     <xsl:element name="div">
       <xsl:attribute name="class">alert <xsl:call-template name="alert-class"><xsl:with-param name="admonition-type" select="@class" /></xsl:call-template></xsl:attribute>
       <strong><xsl:apply-templates select="x:h3[@class='title']/node()" />:</strong><xsl:text> </xsl:text><xsl:apply-templates select="x:p/node()" />
@@ -169,7 +181,7 @@
     Or there can be more elements, in which case we will switch it to “.alert-block” and
     change the heading size to h4 as expected by Bootstrap.
   -->
-  <xsl:template match="x:div[(@class='warning' or @class='note') and count(*) > 2]">
+  <xsl:template match="x:div[(@class='caution' or @class = 'danger' or @class = 'important' or @class = 'note' or @class = 'tip' or @class = 'warning') and count(*) > 2]">
     <xsl:element name="div">
       <xsl:attribute name="class">alert <xsl:call-template name="alert-class"><xsl:with-param name="admonition-type" select="@class" /></xsl:call-template> alert-block</xsl:attribute>
       <h4><xsl:apply-templates select="x:h3[@class='title']/node()" /></h4>

--- a/scripts/bootstrapify-docbook.xsl
+++ b/scripts/bootstrapify-docbook.xsl
@@ -132,60 +132,21 @@
 
 
   <!--
-    Convert admonitions.
-    We mainly need to change the div classes to use the alert component.
-    https://getbootstrap.com/2.3.2/components.html#alerts
+    Allow more precise targetting of admonitions by using more distinct class name.
+    Also use semantic markup and follow rscss guidelines.
   -->
-  <xsl:template name="alert-class">
-    <xsl:param name="admonition-type"/>
-    <xsl:choose>
-      <xsl:when test="$admonition-type = 'caution'">
-        <xsl:value-of select="'alert-danger'"/>
-      </xsl:when>
-      <xsl:when test="$admonition-type = 'danger'">
-        <xsl:value-of select="'alert-danger'"/>
-      </xsl:when>
-      <xsl:when test="$admonition-type = 'important'">
-        <xsl:value-of select="'alert-warning'"/>
-      </xsl:when>
-      <xsl:when test="$admonition-type = 'note'">
-        <xsl:value-of select="'alert-info'"/>
-      </xsl:when>
-      <xsl:when test="$admonition-type = 'tip'">
-        <xsl:value-of select="'alert-info'"/>
-      </xsl:when>
-      <xsl:when test="$admonition-type = 'warning'">
-        <xsl:value-of select="'alert-warning'"/>
-      </xsl:when>
-    </xsl:choose>
-  </xsl:template>
-
-  <!--
-    It can either be a single-paragraph block (the title can be docbook-xsl’s default, or a custom one):
-
-      <div class="note">
-        <h3 class="title">Note</h3>
-        <p>Body</p>
-      </div>
-
-    in which case we turn it into a single line as prefered by Bootstrap.
-  -->
-  <xsl:template match="x:div[(@class='caution' or @class = 'danger' or @class = 'important' or @class = 'note' or @class = 'tip' or @class = 'warning') and count(*) = 2]">
-    <xsl:element name="div">
-      <xsl:attribute name="class">alert <xsl:call-template name="alert-class"><xsl:with-param name="admonition-type" select="@class" /></xsl:call-template></xsl:attribute>
-      <strong><xsl:apply-templates select="x:h3[@class='title']/node()" />:</strong><xsl:text> </xsl:text><xsl:apply-templates select="x:p/node()" />
+  <xsl:template match="x:div[(@class='caution' or @class = 'danger' or @class = 'important' or @class = 'note' or @class = 'tip' or @class = 'warning')]">
+    <xsl:element name="aside">
+      <xsl:attribute name="class">admonition-block -<xsl:value-of select="@class" /></xsl:attribute>
+      <xsl:attribute name="role">note</xsl:attribute>
+      <xsl:apply-templates select="@*[not(name() = 'class')]|node()" />
     </xsl:element>
   </xsl:template>
 
-  <!--
-    Or there can be more elements, in which case we will switch it to “.alert-block” and
-    change the heading size to h4 as expected by Bootstrap.
-  -->
-  <xsl:template match="x:div[(@class='caution' or @class = 'danger' or @class = 'important' or @class = 'note' or @class = 'tip' or @class = 'warning') and count(*) > 2]">
+  <!-- Use div for the admonition title so it does not mess up the document outline. -->
+  <xsl:template match="x:div[(@class='caution' or @class = 'danger' or @class = 'important' or @class = 'note' or @class = 'tip' or @class = 'warning')]/x:h3[@class='title']">
     <xsl:element name="div">
-      <xsl:attribute name="class">alert <xsl:call-template name="alert-class"><xsl:with-param name="admonition-type" select="@class" /></xsl:call-template> alert-block</xsl:attribute>
-      <h4><xsl:apply-templates select="x:h3[@class='title']/node()" /></h4>
-      <xsl:apply-templates select="node()[not(self::x:h3[@class='title'])]" />
+      <xsl:apply-templates select="@*|node()" />
     </xsl:element>
   </xsl:template>
 

--- a/site-styles/pages/manual.less
+++ b/site-styles/pages/manual.less
@@ -1,4 +1,7 @@
 // Manual
+//
+// See: `scripts/bootstrapify-docbook.xsl`
+//
 
 .docbook-page {
   .hidden {
@@ -126,18 +129,24 @@ div.docbook {
   .admonition-block {
     &:extend(.notice-box all);
 
-    &.-note, &.-tip {
-      &:extend(.notice-box.-info);
-    }
-    &.-important, &.-warning {
-      &:extend(.notice-box.-warning);
-    }
-    &.-important, &.-warning {
-      // TODO: Add red notice-box.
+    > .title {
+      #theme.h6();
+      color: inherit;
+      margin-bottom: 0;
     }
 
-    > .title {
-      // TODO: Style appropriately.
+    // Variant styles
+    &.-important,
+    &.-note,
+    &.-tip {
+      &:extend(.notice-box.-info);
+    }
+    &.-caution,
+    &.-warning {
+      &:extend(.notice-box.-warning);
+    }
+    &.-danger, {
+      &:extend(.notice-box.-danger);
     }
   }
 }

--- a/site-styles/pages/manual.less
+++ b/site-styles/pages/manual.less
@@ -123,14 +123,21 @@ div.docbook {
     &:extend(.terminal-console all);
   }
 
-  // From bootstrapify docbook
-  .alert {
+  .admonition-block {
     &:extend(.notice-box all);
-  }
-  .alert-info {
-    &:extend(.notice-box.-info);
-  }
-  .alert-warning {
-    &:extend(.notice-box.-warning);
+
+    &.-note, &.-tip {
+      &:extend(.notice-box.-info);
+    }
+    &.-important, &.-warning {
+      &:extend(.notice-box.-warning);
+    }
+    &.-important, &.-warning {
+      // TODO: Add red notice-box.
+    }
+
+    > .title {
+      // TODO: Style appropriately.
+    }
   }
 }


### PR DESCRIPTION
When an admonition contained other elements than paragraphs (e.g. pre), they were removed. Additionally, custom titles were replaced in single-paragraph admonitions by generic ones and all titles were stripped in multi-paragraph ones.

With this patch, the stylesheet should preserve all contents of admonitions when trying to Bootstapify them.

### Example

Noticed by @maralorn and reported on [Matrix](https://matrix.to/#/!kjdutkOsheZdjqYmqp:nixos.org/$pwoosV97vjUhIwO-Lh-18MJvvvDTAmF67sHC-FazFDs?via=nixos.org&via=matrix.org&via=nixos.dev).

#### On the website
[![Note in manual on the website](https://user-images.githubusercontent.com/705123/144734619-9226a713-c8d5-429f-9ff6-1232c21b614c.png)](https://nixos.org/manual/nixos/stable/index.html#sec-booting-from-usb)

#### Untransformed manual
![Note in manual built in nixpkgs repo](https://user-images.githubusercontent.com/705123/144734658-981f1daf-e02e-4bcf-93f6-5c7051f4e277.png)

#### Fixed (current style)

![Note after the fix](https://user-images.githubusercontent.com/705123/144734759-a2a368ff-a06c-4daa-9b33-f19d8907e9e5.png)
