### PR TITLE
Fix Nix.dev guides

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,7 +164,7 @@ rec {
 
             export NIXOS_AMIS="${nixosAmis}"
             export NIX_PILLS_MANUAL_IN="${nixPills}/share/doc/nix-pills"
-            export NIX_DEV_MANUAL_IN="${nix-dev.defaultPackage.x86_64-linux}/html"
+            export NIX_DEV_MANUAL_IN="${nix-dev.defaultPackage.x86_64-linux}"
 
             rm -f site-styles/common-styles
             ln -s ${nixos-common-styles.packages."${system}".commonStyles} site-styles/common-styles

--- a/scripts/copy-nix-dev-tutorials.sh
+++ b/scripts/copy-nix-dev-tutorials.sh
@@ -24,11 +24,11 @@ for page in "${pages[@]}"; do
   source="$NIX_DEV_MANUAL_IN/$page"
   target="$outDir/$filename.tt"
   temp="$target.temp"
-  title=$(xidel $source --css '.body h1' --printed-node-format=text | sed 's|¶||')
+  title=$(xidel $source --css '#main-content h1' --printed-node-format=text | sed 's|¶||')
 
   echo "<li><a href=\"/$outDir/$filename.html\">$title</a></li>" >> learn_guides.html.in
 
-  xidel $source --css '.body > .section > *' --printed-node-format=html \
+  xidel $source --css '#main-content > div > div > .section > *' --printed-node-format=html \
     | sed 's|<a class=\"headerlink\".*<\/a>||g' \
     | sed 's|<a class="reference internal" href="../glossary.html#term-attribute-name"><span class="xref std std-term">attribute name</span></a>|attribute name|g' \
     | sed 's|<a class="reference internal" href="../glossary.html#term-package-name"><span class="xref std std-term">package name</span></a>|package name|g' \


### PR DESCRIPTION
https://github.com/NixOS/nixos-homepage/commit/f3ba34321f38e372a05a2f3f2eb53a46a1a43c45 updated nix.dev flake to a version using a different theme:

https://github.com/nix-dot-dev/nix.dev/commit/d177dba53b5dae69bc3347b8c58aee30af7e186f

This patch adjusts the XPath expressions to match what sphinx-book-theme uses. Unfortunately, the theme just uses anonymous divs so the XPath is not very robust.

Fixes: https://github.com/NixOS/nixos-homepage/issues/768

cc @domenkozar 