### PR TITLE
Sync again with nix.dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,16 +24,17 @@ HTML = \
   download.html \
   explore.html \
   guides/ad-hoc-developer-environments.html \
-  guides/building-and-running-docker-images.html \
-  guides/continuous-integration-github-actions.html \
-  guides/contributing.html \
-  guides/declarative-and-reproducible-developer-environments.html \
-  guides/deploying-nixos-using-terraform.html \
-  guides/dev-environment.html \
-  guides/how-nix-works.html \
-  guides/install-nix.html \
-  guides/cross-compilation.html \
   guides/towards-reproducibility-pinning-nixpkgs.html \
+  guides/declarative-and-reproducible-developer-environments.html \
+  guides/continuous-integration-github-actions.html \
+  guides/dev-environment.html \
+  guides/building-and-running-docker-images.html \
+  guides/building-bootable-iso-image.html \
+  guides/deploying-nixos-using-terraform.html \
+  guides/installing-nixos-on-a-raspberry-pi.html \
+  guides/integration-testing-using-virtual-machines.html \
+  guides/cross-compilation.html \
+  guides/contributing.html \
   index.html \
   learn.html
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ HTML = \
   guides/dev-environment.html \
   guides/how-nix-works.html \
   guides/install-nix.html \
+  guides/cross-compilation.html \
   guides/towards-reproducibility-pinning-nixpkgs.html \
   index.html \
   learn.html

--- a/blog/index.tt
+++ b/blog/index.tt
@@ -1526,7 +1526,7 @@ for the next edition or look at the
 <p>lorri is based around fast direnv integration for robust CLI and editor integration.</p>
 <p><a href="http://github.com/target/lorri">Try it out</a></p>
 <ul>
-<li><a href="https://nixos.org/releases/patchelf/patchelf-0.10/">PatchELF 0.10 released</a></li>
+<li><a href="https://releases.nixos.org/?prefix=patchelf/patchelf-0.10/">PatchELF 0.10 released</a></li>
 </ul>
 <h2>Contribute to NixOS Weekly Newsletter</h2>
 <p>This work would not be possible without the many contributions of the community.</p>

--- a/download.tt
+++ b/download.tt
@@ -6,7 +6,7 @@
   <h1>Download</h1>
 </div>
 
-<section class="download-header">
+<section id="download-nix" class="download-header">
   <div>
     <h1>Nix</h1>
     <div>
@@ -16,7 +16,7 @@
   </div>
 </section>
 
-<section id="download-nix" class="download-nix">
+<section class="download-nix">
   <div class="collapse">
     <div>
       <article id="nix-quick-install">
@@ -70,7 +70,7 @@
   </div>
 </section>
 
-<section class="download-header">
+<section id="download-nixos" class="download-header">
   <div>
     <h1>NixOS</h1>
     <div>
@@ -80,7 +80,7 @@
   </div>
 </section>
 
-<section id="download-nixos" class="download-nixos">
+<section class="download-nixos">
   <div class="collapse">
     <div>
       <article id="nixos-iso">

--- a/download.tt
+++ b/download.tt
@@ -19,20 +19,85 @@
 <section class="download-nix">
   <div class="collapse">
     <div>
-      <article id="nix-quick-install">
-        <h2>Quick install</h2>
+      <article id="nix-install-linux">
+        <h2>Linux</h2>
         <p>
-          The quickest way to install Nix is to open a terminal and run the following
-          command (as a user other than <code>root</code> with <code>sudo</code> permission):
+          Install Nix on via the recommended
+          <a href="[%nixManual%]/installation/multi-user.html">multi-user installation</a>:
         </p>
         <pre class="terminal-console">
-<span class="shell-prompt">$ </span>curl -L https://nixos.org/nix/install | sh</pre>
-        <p>Make sure to follow the instructions output by the script.</p>
-        <p>The installation script requires that you have <code>sudo</code> access to <code>root</code>.</p>
+<span class="shell-prompt">$ </span>sh &lt;(curl -L https://nixos.org/nix/install) --daemon</pre>
+        <aside class="notice-box -warning">
+          <strong>Note:</strong>
+          For security you may want to 
+          <a href="[%root%]download.html#nix-verify-installation">verify the installation script</a>
+          using GPG signatures.
+        </aside>
       </article>
+
+      <article id="nix-install-macosx">
+        <h2>MacOS</h2>
+        <p>
+          Install Nix on via the recommended
+          <a href="[%nixManual%]/installation/multi-user.html">multi-user installation</a>:
+        </p>
+        <pre class="terminal-console">
+<span class="shell-prompt">$ </span>sh &lt;(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume --daemon</pre>
+        <aside class="notice-box -warning">
+          <strong>Note:</strong>
+          For security you may want to 
+          <a href="[%root%]download.html#nix-verify-installation">verify the installation script</a>
+          using GPG signatures.
+        </aside>
+      </article>
+
+      <article id="nix-install-windows">
+        <h2>Windows (WSL2)</h2>
+        <p>
+          Install Nix via the
+          <a href="[%nixManual%]/installation/single-user.html">single-user installation</a>:
+        </p>
+        <pre class="terminal-console">
+<span class="shell-prompt">$ </span>sh &lt;(curl -L https://nixos.org/nix/install) --no-daemon</pre>
+        <aside class="notice-box -warning">
+          <strong>Note:</strong>
+          For security you may want to
+          <a href="[%root%]download.html#nix-verify-installation">verify the installation script</a>
+          using GPG signatures.
+        </aside>
+      </article>
+
+      <article id="nix-install-docker">
+        <h2>Docker</h2>
+        <p>Start a Docker shell with Nix:</p>
+        <pre class="terminal-console">
+<span cls="shell-prompt">$ </span>docker run -it nixos/nix</pre>
+        <p>Or start a Docker shell with Nix exposing a <code>workdir</code> directory:</p>
+        <pre class="terminal-console">
+<span cls="shell-prompt">$ </span>mkdir workdir
+<span cls="shell-prompt">$ </span>docker run -it -v $(pwd)/workdir:/workdir nixos/nix</pre>
+        <p>The <code>workdir</code> example from above can be also used to start hacking on nixpkgs:</p>
+        <pre class="terminal-console">
+<span cls="shell-prompt">$ </span>git clone git@github.com:NixOS/nixpkgs
+<span cls="shell-prompt">$ </span>docker run -it -v $(pwd)/nixpkgs:/nixpkgs nixos/nix
+<span cls="shell-prompt">docker&gt; </span>nix-build -I nixpkgs=/nixpkgs -A hello
+<span cls="shell-prompt">docker&gt; </span>find ./result # this symlink points to the build package</pre>
+      </article>
+
       <article id="nix-verify-installation">
         <h2>Verify installation</h2>
-        <p>You may want to verify the integrity of the installation script using GPG:</p>
+        <p>
+          Check that the installation by opening
+          <strong>a new terminal</strong> and typing:
+        </p>
+        <pre class="terminal-console">
+<span cls="shell-prompt">$ </span>nix-env --version
+nix-env (Nix) 2.3.15</pre>
+        <p>
+          You may want to verify the
+          <strong>integrity of the installation script</strong>
+          using GPG:
+        </p>
         <pre class="terminal-console">
 <span cls="shell-prompt">$ </span>curl -o install-nix-[%latestNixVersion%] https://releases.nixos.org/nix/nix-[%latestNixVersion%]/install
 <span cls="shell-prompt">$ </span>curl -o install-nix-[%latestNixVersion%].asc https://releases.nixos.org/nix/nix-[%latestNixVersion%]/install.asc
@@ -45,13 +110,6 @@
           It is also available
           <a href="https://github.com/NixOS/nixos-homepage/blob/master/edolstra.gpg">on GitHub</a>.
         </p>
-      </article>
-      <article id="nix-uninstall">
-        <h2>Uninstall</h2>
-        <p>
-          You can uninstall Nix simply by running <code>rm -rf /nix</code>.
-        </p>
-        <!-- TODO: expand this https://github.com/NixOS/nix/issues/1402 -->
       </article>
       <article id="nix-more">
         <h2>More ...</h2>

--- a/learn.tt
+++ b/learn.tt
@@ -8,7 +8,7 @@
   <ul>
     <li>
       <div class="clickable-whole">
-        <a href="[%root%]guides/install-nix.html">
+        <a href="[%root%]download.html#download-nix">
           [% PROCESS svg path="site-styles/assets/gfx-learn-install.svg" %]
           <button>Install Nix</button>
         </a>

--- a/scripts/copy-nix-dev-tutorials.sh
+++ b/scripts/copy-nix-dev-tutorials.sh
@@ -3,14 +3,17 @@
 set -e
 
 pages=(
-  "tutorials/install-nix.html"
+  # "tutorials/install-nix.html" # Not needed since this is part of Download page
   "tutorials/ad-hoc-developer-environments.html"
-  "tutorials/declarative-and-reproducible-developer-environments.html"
-  "tutorials/dev-environment.html"
   "tutorials/towards-reproducibility-pinning-nixpkgs.html"
+  "tutorials/declarative-and-reproducible-developer-environments.html"
   "tutorials/continuous-integration-github-actions.html"
+  "tutorials/dev-environment.html"
   "tutorials/building-and-running-docker-images.html"
+  "tutorials/building-bootable-iso-image.html"
   "tutorials/deploying-nixos-using-terraform.html"
+  "tutorials/installing-nixos-on-a-raspberry-pi.html"
+  "tutorials/integration-testing-using-virtual-machines.html"
   "tutorials/cross-compilation.html"
   "tutorials/contributing.html"
 )

--- a/scripts/copy-nix-dev-tutorials.sh
+++ b/scripts/copy-nix-dev-tutorials.sh
@@ -11,6 +11,7 @@ pages=(
   "tutorials/continuous-integration-github-actions.html"
   "tutorials/building-and-running-docker-images.html"
   "tutorials/deploying-nixos-using-terraform.html"
+  "tutorials/cross-compilation.html"
   "tutorials/contributing.html"
 )
 


### PR DESCRIPTION
- Add missing tutorials from nix.dev
- Move `Install Nix` tutorial to be included in Download page
- Fix link to PatchELF
