### PR TITLE
flake: Update pills attribute reference

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,11 +71,11 @@
     "nix-pills": {
       "flake": false,
       "locked": {
-        "lastModified": 1656456223,
-        "narHash": "sha256-gNf5Z8ERvzuadiQm1+2WDqzA0huK3JekmQG0EqgIzjM=",
+        "lastModified": 1662023419,
+        "narHash": "sha256-z3ZOzt3/9CKjEQiDZducsA4vgSPFIGsIcMdcezGaHi0=",
         "owner": "NixOS",
         "repo": "nix-pills",
-        "rev": "4f3df4b375ad81360bec1df4bfe02c92d1cdd90f",
+        "rev": "9fef24423b0a8087009050305be87e6f5b67aa95",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,7 @@ rec {
               "NIXOS_UNSTABLE_SERIES=${pkgs-unstable.lib.trivial.release}"
 
               "NIXOS_AMIS=${nixosAmis}"
-              "NIX_PILLS_MANUAL_IN=${nixPills}/share/doc/nix-pills"
+              "NIX_PILLS_MANUAL_IN=${nixPills.html-split}/share/doc/nix-pills"
               "NIX_DEV_MANUAL_IN=${nix-dev.defaultPackage.x86_64-linux}"
 
               "-j 1"
@@ -166,7 +166,7 @@ rec {
             export NIXOS_UNSTABLE_SERIES="${pkgs-unstable.lib.trivial.release}"
 
             export NIXOS_AMIS="${nixosAmis}"
-            export NIX_PILLS_MANUAL_IN="${nixPills}/share/doc/nix-pills"
+            export NIX_PILLS_MANUAL_IN="${nixPills.html-split}/share/doc/nix-pills"
             export NIX_DEV_MANUAL_IN="${nix-dev.defaultPackage.x86_64-linux}"
 
             rm -f site-styles/common-styles


### PR DESCRIPTION
Pills now have an EPUB output so we need to update the attribute name.

Depends on: https://github.com/NixOS/nix-pills/pull/189
