### PR TITLE
Remove installer flags deprecated as of Nix 2.4

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -73,7 +73,7 @@
       </article>
 
       <article id="nix-install-macos">
-        <h2>macOS</h2>
+        <h2>MacOS</h2>
         <h3>Multi-user installation</h3>
         <p>
           Install Nix via the

--- a/download.tt
+++ b/download.tt
@@ -72,8 +72,8 @@
         </ul>
       </article>
 
-      <article id="nix-install-macosx">
-        <h2>MacOS</h2>
+      <article id="nix-install-macos">
+        <h2>macOS</h2>
         <h3>Multi-user installation</h3>
         <p>
           Install Nix via the
@@ -81,9 +81,7 @@
           <a href="[%nixManual%]/installation/multi-user.html">multi-user installation</a>:
         </p>
         <pre class="terminal-console">
-<span class="shell-prompt">$ </span>sh &lt;(curl -L https://nixos.org/nix/install) \
-        --darwin-use-unencrypted-nix-store-volume \
-        --daemon</pre>
+<span class="shell-prompt">$ </span>sh &lt;(curl -L https://nixos.org/nix/install)</pre>
         <p>
           We believe we have ironed out how to cleanly support the read-only
           root on modern macOS. Please


### PR DESCRIPTION
As of Nix 2.4, the `--darwin-use-unencrypted-nix-store-volume` flag was
deprecated and prints a warning. Single user installations on macOS are
no longer supported so the `--daemon` flag is unnecessary.