### PR TITLE
Fix broken URL to release notes

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -149,7 +149,7 @@ nix-env (Nix) 2.3.15</pre>
         <h2>More ...</h2>
         <p>The following release items are also available:</p>
         <ul>
-          <li><a href="[%nixManual%]/release-notes/rl-[%latestNixVersion%].html">Release notes</a></li>
+          <li><a href="[%nixManual%]/release-notes/rl-[%latestNixVersion | remove('\.0$')%].html">Release notes</a></li>
           <li>
             <a href="[%nixManual%]">Manual</a>.
             Please read the <a href="[%nixManual%]/quick-start.html">“Quick Start” section of the manual</a>


### PR DESCRIPTION
The URL for the nix package manager release notes does not include the
patch version when the patch version is `0`, i.e. on new minor and major
releases. This currently causes a broken link on download page to the
release notes of the latest version of nix.

For example, the download page currently generates a link for
`release-notes/rl-2.6.0.html`, however the actual URL for the release
notes is `release-notes/rl-2.6.html`.

This commit removes the patch version from the URL to the release notes
when the patch version is `0`.