### PR TITLE
Specify supported Linux platforms on Download page

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -31,7 +31,7 @@
         <pre class="terminal-console">
 <span class="shell-prompt">$ </span>sh &lt;(curl -L https://nixos.org/nix/install) --daemon</pre>
         <p>
-          We recommend the multi-user install if it supports your platform and
+          We recommend the multi-user install if you are on Linux running systemd, with SELinux disabled and
           you can authenticate with <code>sudo</code>.
         </p>
 


### PR DESCRIPTION
There is a [long-standing issue](https://github.com/NixOS/nix/issues/2374) where the multi-user installation fails on systems that enable SELinux. The user then gets to clean up the nixbld users and whatnot.
Unfortunately, the Download page is not very helpful. While it recommends the multi-user installation only for supported systems, it doesn't link to the [manual page that specifies these](https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation).
I considered adding said link, but I think it's better to mention it directly. The wording is copied directly from the manual.