### PR TITLE
Fix navigation links for sub-pages

### DIFF
--- a/layout.tt
+++ b/layout.tt
@@ -11,7 +11,9 @@ USE date;
 # class: Additional classes
 BLOCK navigationLink %]
 
-<li class="[% outputName == href ? " active" : "" %] [% class %]">
+[% SET outputPrefix = outputName.split('/').first %]
+
+<li class="[% outputPrefix == href ? " active" : "" %] [% class %]">
   [%- IF href -%]
   <a href="[% root %][% href %]">[% title %]</a>
   [%- ELSE -%]
@@ -57,8 +59,8 @@ BLOCK navigationLink %]
           [% INCLUDE navigationLink href="explore.html" title="Explore" %]
           [% INCLUDE navigationLink href="download.html" title="Download" %]
           [% INCLUDE navigationLink href="learn.html" title="Learn" %]
-          [% INCLUDE navigationLink href="community/index.html" title="Community" %]
-          [% INCLUDE navigationLink href="blog/index.html" title="Blog" %]
+          [% INCLUDE navigationLink href="community" title="Community" %]
+          [% INCLUDE navigationLink href="blog" title="Blog" %]
           [% INCLUDE navigationLink href="donate.html" title="Donate" %]
           [% WRAPPER navigationLink class="search" title="Search" %]
           <a href="https://search.nixos.org/packages">Search</a>


### PR DESCRIPTION
`blog` and `community` navigation links have sub-pages (e.g.
blog/categories.html, community/commercial-support.html etc).

Previosly, if user was to navigate to such sub-pages, navigation links
would not be active.

To fix this, we now check if `outputName` prefix matches `href` specified in
navigation link (e.g. `blog/categories.html` will match `blog` prefix).


Before:
<img width="646" alt="Before" src="https://user-images.githubusercontent.com/1084748/162947588-9db34002-aa67-41da-96c6-4f82dfcf9089.png">

After:
<img width="663" alt="after" src="https://user-images.githubusercontent.com/1084748/162947632-349e5de5-efc3-4216-b297-67acd1843dba.png">
