### PR TITLE
Build Github pages for pull requests

### DIFF
--- a/.github/actions/generate-pages/action.yml
+++ b/.github/actions/generate-pages/action.yml
@@ -1,0 +1,31 @@
+name: Update pages
+description: Updates the page for the current branch
+runs:
+  using: composite
+  steps:
+    - name: Build
+      shell: bash
+      run: |
+        set -x
+        # Find the name of the branch/tag
+        # ref_name doesn't work for pull requests as head_ref points to the source ref
+        ref_name="${{ github.head_ref || github.ref_name }}"
+        tmp_page_dir="/tmp/${ref_name}"
+        
+        # Update the "webroot" for the generated homepage
+        repo_name="$(echo ${{ github.repository }} | cut -d / -f 2)"
+        sed -i -re "s|ROOT = .+|ROOT = \"/$repo_name/pages/$ref_name/\"|g" Makefile
+        grep ROOT Makefile
+        
+        # Build the homepage
+        nix build
+        
+        # Undo changes to Makefile
+        git checkout -- .
+        
+        # Checkout pages branch and be ready to commit the generated homepage
+        mkdir -p "$tmp_page_dir"
+        cp -RL ./result/* ./result/.well-known/ "${tmp_page_dir}"
+        git checkout pages
+        rm -rf "pages/${ref_name}"
+        cp -RL "${tmp_page_dir}" "pages/${ref_name}"

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,36 @@
+name: "Install dependencies"
+description: "Install common nix dependencies"
+inputs:
+  cachix_signing_key:
+    description: "Cachix signing key"
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Installing Nix
+      uses: cachix/install-nix-action@v17
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Install unstable channel
+      shell: bash
+      run: |
+        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+        nix-channel --update
+
+    - name: Installing NixFlakes
+      shell: bash
+      run: |
+        nix-env -iA nixpkgs.nixFlakes
+        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
+        nix --version
+        cat /etc/nix/nix.conf
+        echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
+
+    - name: Setup Cachix
+      if: "inputs.cachix_signing_key != ''"
+      uses: cachix/cachix-action@v10
+      with:
+        name: nixos-homepage
+        signingKey: '${{ inputs.cachix_signing_key }}'

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,33 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
-    - name: Checking out the repository
-      uses: actions/checkout@v3
+      - name: Checking out the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+    - name: Install deps
+      uses: ./.github/actions/install-deps
       with:
-        fetch-depth: 0
-
-    - name: Installing Nix
-      uses: cachix/install-nix-action@v17
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-
-    - name: Install unstable channel
-      run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-        nix-channel --update
-
-    - name: Installing NixFlakes
-      run: |
-        nix-env -iA nixpkgs.nixFlakes
-        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-        nix --version
-        cat /etc/nix/nix.conf
-        echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
-
-    - uses: cachix/cachix-action@v10
-      with:
-        name: nixos-homepage
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        cachix_signing_key: "${{ secrets.CACHIX_SIGNING_KEY }}
 
     - name: Update content
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,6 +1,5 @@
 name: "Build & Deploy to Netlify"
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,18 +14,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Installing Nix
-      uses: cachix/install-nix-action@v17
+    - name: Install deps
+      uses: ./.github/actions/install-deps
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
-        extra_nix_config: |
-          experimental-features = nix-command flakes
-
-    - name: Setup Cachix
-      uses: cachix/cachix-action@v10
-      with:
-        name: nixos-homepage
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        cachix_signing_key: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
     - name: Building nixos.org
       run: |

--- a/.github/workflows/pull_request_pages.yml
+++ b/.github/workflows/pull_request_pages.yml
@@ -1,0 +1,54 @@
+name: "Build Github Pages for pull requests"
+
+on:
+  pull_request:
+jobs:
+  generate-pages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checking out the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: "Install deps"
+        if: github.event.pull_request.merged != true
+        uses: ./.github/actions/install-deps
+
+      - name: "Generate pages"
+        if: github.event.pull_request.merged != true
+        uses: ./.github/actions/generate-pages
+
+      - name: "Delete pages"
+        if: github.event.pull_request.merged == true
+        run: |
+          rm -rf "pages/${{ github.head_ref || github.ref_name }}"
+
+      - name: "Update page index"
+        run: |
+          index(){
+            echo "<h1>Branches</h1>"
+            echo "<ul>"
+            for dir in $(ls pages) ; do
+              echo "<li><a href='pages/$dir'>$dir</a></li>"
+            done
+            echo "</ul>"
+          }
+          index > index.html
+
+      - name: Commit updated files and push them to master branch
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Update ${{ github.head_ref || github.ref_name }}"
+          branch: 'pages'
+          file_pattern: index.html pages
+          commit_user_name: NixOS webmaster
+          commit_user_email: webmaster@nixos.org
+          commit_author: GitHub Actions <webmaster@nixos.org>
+
+      - name: Check out the repository again for post action steps
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0


### PR DESCRIPTION
Since this project generates a static site, one can take advantage of [Github Pages](https://pages.github.com/) to host it. In the case of this PR, it introduces the ability to review the the static site generated by pull requests.

Another benefit is that modifications need not require the lengthy installation of `nix` (related to #833)

# How it works

The PR will build the static site, modify the `pages` branch by adding a new directory with the name of the PR branch in the `/pages/` folder and updating `/index.html` with the list of directories therein, then finally push it. This allows for PRs to reviewed by navigating to the github pages URL (example below). 

# Required setup

 - Create `pages` branch
 - Use `pages` branch as the [source for Github Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site) on this project

# Example result

LoveisGrief/nixos-homepage#1 showcases the [result](https://loveisgrief.github.io/nixos-homepage/)

# Possible pitfalls

**Branch name collision**

Since the branch name is used I'm not sure what the source branch names look like for forked repos. PRs with the same branch name might overwrite each other, but I'm not sure. I used [`github.head_ref`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context). Using `github.ref_name` gave me `1/merge` which I assume is the PR number with `/merge` (?).