### PR TITLE
Add docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nixos/nix
+
+RUN echo 'experimental-features = nix-command flakes' | tee -a /etc/nix/nix.conf
+
+WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you feel lost where and how to contribute, ask the [marketing team](https://n
 
 # How to help?
 
-To run local development instance follow this steps:
+To run local development instance follow this steps to start a local server
 
     $ git clone git@github.com:NixOS/nixos-homepage.git
     $ cd nixos-homepage
@@ -34,12 +34,20 @@ To run local development instance follow this steps:
 
     [nix-shell]$ serve
 
+If you have [Docker] and [Docker Compose] installed, you can alternatively run
+
+    $ docker-compose up
+
+Once everything's ready, you'll be able to access 
+
 Open your browser at: http://localhost:8000/
 
 In order for the browser to automatically refresh, install the [Livereload extension](http://livereload.com/extensions/) for your browser.
 
 Before creating a pull request make sure that `nix-build` runs successfully.
 
+[Docker]: https://docs.docker.com/get-docker/
+[Docker Compose]: https://docs.docker.com/compose/install/  
 
 ## Binary cache (Optional)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  nixos-homepage:
+    build:
+      context: .
+    environment:
+      HOST: "0.0.0.0"
+    ports:
+      - 8000:8000
+    volumes:
+      - .:/app
+    command:
+      - nix
+      - develop
+      - --command
+      - serve

--- a/scripts/serve.py
+++ b/scripts/serve.py
@@ -41,7 +41,7 @@ def main(common_styles):
 
     os.system("make")
 
-    server.serve(root="./", port=os.getenv("PORT", 8000))
+    server.serve(host=os.getenv("HOST", "localhost"), root="./", port=os.getenv("PORT", 8000))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR removes the dependency on `nix` to be in the developer's environment and adds docker as an alternative.

Related to #833

# Reasoning

I'm probably not the only person here who would like to contribute to the homepage and nix/nixos documentation,
 but doesn't necessarily have `nix` itself installed on my dev machine or in my dev environment.
There are probably other usecases as well, but for me personally, I main a non nixOS distro (opensuse) and don't want to take
 my chances of messing up this install. So, nixOS is on a separate laptop which is purely for testing nixOS and doesn't have
 my developer secrets.

This helps me contribute and might help others contribute who just swing by and don't want to install yet another tool
 in order to contribute just some HTML or CSS.