### PR TITLE
first steps: link to "ad hoc developer environments"

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -16,7 +16,7 @@
     </li>
     <li>
       <div class="clickable-whole">
-        <a href="[%root%]guides/dev-environment.html">
+        <a href="[%root%]guides/ad-hoc-developer-environments.html">
           [% PROCESS svg path="site-styles/assets/gfx-learn-develop.svg" %]
           <button>First steps with Nix</button>
         </a>


### PR DESCRIPTION
from observing absolute Nix beginners: while software
developers immediately want to use declarative environments, they also
require them to work for their programming language of choice. this is
not feasible on short notice, as they have to learn some concepts first
to make use of the language-specific examples in the manual.

anyone not working with python will find the python example useless.

the article linked now is directly targeted to absolute beginners, and
is therefore most suitable for "first steps".