### PR TITLE
where to talk: make forum first list item

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -28,17 +28,17 @@
   <h1 id="platforms">Where to talk?</h1>
   <div>
     <div>
-      <h2>Chat</h2>
-      <p>Real-time help, development chat, and off-topic community discussion
-        takes place on Matrix.</p>
-      <a href="https://matrix.to/#/#community:nixos.org">NixOS Matrix Space</a>
-    </div>
-    <div>
       <h2>Forum</h2>
       <p>The official forum is the right place to get help from other users and
         discuss the development of the projects. There are also Announcements,
         Job offers and Events.</p>
       <a href="https://discourse.nixos.org/">Discourse Forum</a>
+    </div>
+    <div>
+      <h2>Chat</h2>
+      <p>Real-time help, development chat, and off-topic community discussion
+        takes place on Matrix.</p>
+      <a href="https://matrix.to/#/#community:nixos.org">NixOS Matrix Space</a>
     </div>
     <div>
       <h2>Other Platforms</h2>


### PR DESCRIPTION
NixOS Discourse is the central community platform and should be listed
first.