### PR TITLE
Fix self link in RSS feed.

### DIFF
--- a/blog/announcements-rss.xsl
+++ b/blog/announcements-rss.xsl
@@ -19,7 +19,7 @@
       <channel>
         <title>NixOS News</title>
         <link>https://nixos.org/news.html</link>
-        <atom:link href="https://nixos.org/news-rss.xml" rel="self" type="application/rss+xml" />
+        <atom:link href="https://nixos.org/blog/announcements-rss.xml" rel="self" type="application/rss+xml" />
         <description>News for NixOS, the purely functional Linux distribution.</description>
         <fh:complete xmlns:fh="http://purl.org/syndication/history/1.0"/>
 


### PR DESCRIPTION
Previously it pointed at a URL which just redirected here.