### PR TITLE
learn.html: fix broken language section anchors

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -135,7 +135,7 @@
           <li>
             Integrate Nix with programming languages:
             <ul class="comma-separated">
-              <li><a href="[%root%]manual/nixpkgs/stable/#node.js">Javascript (Node)</a></li>
+              <li><a href="[%root%]manual/nixpkgs/stable/#language-javascript">Javascript (Node)</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#python">Python</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-language-ruby">Ruby</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-language-java">Java</a></li>
@@ -145,7 +145,7 @@
               <li><a href="[%root%]manual/nixpkgs/stable/#haskell">Haskell</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-elm">Elm</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-beam">BEAM Languages (Erlang, Elixir, LFE)</a></li>
-              <li><a href="[%root%]manual/nixpkgs/stable/#sec-language-lua">Lua</a></li>
+              <li><a href="[%root%]manual/nixpkgs/stable/#users-guide-to-lua-infrastructure">Lua</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#idris">Idris</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-language-coq">Coq</a></li>
               <li><a href="[%root%]manual/nixpkgs/stable/#sec-language-perl">Perl</a></li>


### PR DESCRIPTION
Noticed that the link on the [learn page](https://nixos.org/learn.html) for Javascript was broken (well, it pointed to a non-existent anchor on the page), this PR fixes that.

![image](https://user-images.githubusercontent.com/1675190/177103470-554d0a84-e49e-4d7e-a8bf-ab073c0ed7ff.png)
