### PR TITLE
make NixOS Wiki official

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -209,21 +209,21 @@
 
 <section class="learn-otherresources">
   <div>
-    <h1>Other learning resources</h1>
+    <h1>Learning resources</h1>
     <ul>
-      <li class="clickable-whole">
-        <h3>Unofficial Wiki</h3>
-        <p>
-          A user-maintained wiki for Nix and NixOS.
-        </p>
-        <a href="https://nixos.wiki">Read more</a>
-      </li>
       <li class="clickable-whole">
         <h3>nix.dev</h3>
         <p>
-          An unofficial and opinionated guide for developers getting things done using the Nix ecosystem.
+          Guides to getting things done in the Nix ecosystem.
         </p>
         <a href="https://nix.dev">Read more</a>
+      </li>
+      <li class="clickable-whole">
+        <h3>NixOS Wiki</h3>
+        <p>
+          The community Wiki for Nix and NixOS.
+        </p>
+        <a href="https://nixos.wiki">Read more</a>
       </li>
       <li class="clickable-whole">
         <h3>Nix Pills</h3>


### PR DESCRIPTION
- [decided on 2022-06-23](https://discourse.nixos.org/t/2022-06-23-documentation-team-meeting-notes-2/20005)
- formalized for [Summer of Nix 2022](https://discourse.nixos.org/t/summer-of-nix-documentation-stream/20351#how-to-contribute-to-documentation-6) and [Nix documentation team](https://discourse.nixos.org/t/documentation-team-flattening-the-learning-curve/20003#responsibilities-4)

TODO:
- [ ] change nixos.wiki front page to remove "unofficial"
- [ ] clarify [responsibilities](https://github.com/NixOS/nix.dev/issues/279) and further consequences