### PR TITLE
Nix language manual redirect for all versions

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -112,36 +112,33 @@
   status = 302
   force = true
 
-# IMPORTANT: add `stable` variants to the following Nix manual redirects
-# once https://github.com/NixOS/nix/pull/6863 is on a release branch!
-
 [[redirects]]
-  from = "/manual/nix/unstable/expressions/expression-language.html"
-  to = "/manual/nix/unstable/language/index.html"
+  from = "/manual/nix/:version/expressions/expression-language.html"
+  to = "/manual/nix/:version/language/index.html"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/manual/nix/unstable/expressions/language-values.html"
-  to = "/manual/nix/unstable/language/values.html"
+  from = "/manual/nix/:version/expressions/language-values.html"
+  to = "/manual/nix/:version/language/values.html"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/manual/nix/unstable/expressions/language-constructs.html"
-  to = "/manual/nix/unstable/language/constructs.html"
+  from = "/manual/nix/:version/expressions/language-constructs.html"
+  to = "/manual/nix/:version/language/constructs.html"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/manual/nix/unstable/expressions/language-operators.html"
-  to = "/manual/nix/unstable/language/operators.html"
+  from = "/manual/nix/:version/expressions/language-operators.html"
+  to = "/manual/nix/:version/language/operators.html"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/manual/nix/unstable/expressions/*"
-  to = "/manual/nix/unstable/language/:splat"
+  from = "/manual/nix/:version/expressions/*"
+  to = "/manual/nix/:version/language/:splat"
   status = 302
   force = true
 


### PR DESCRIPTION
@garbas this is broken right now since the last Nix release. The previous PR only had redirects for the `unstable` branch.