### PR TITLE
Update steering committee

### DIFF
--- a/community/teams/rfc-steering-committee.tt
+++ b/community/teams/rfc-steering-committee.tt
@@ -19,10 +19,9 @@
   <aside>
     <h2>Members</h2>
     <ul>
+      <li><a href="https://discourse.nixos.org/u/tomberek">Tom Bereknyei</a> (tomberek)</li>
+      <li><a href="https://discourse.nixos.org/u/kevincox">Kevin Cox</a> (kevincox)</li>
       <li><a href="https://discourse.nixos.org/u/edolstra">Eelco Dolstra</a> (niksnut)</li>
-      <li><a href="https://discourse.nixos.org/u/mic92">Jörg Thalheim</a> (Mic92)</li>
-      <li><a href="https://discourse.nixos.org/u/spacekookie">Katharina Fey</a> (spacekookie)</li>
-      <li><a href="https://discourse.nixos.org/u/kloenk">Finn Behrens</a> (kloenk)</li>
       <li><a href="https://discourse.nixos.org/u/lheckemann">Linus Heckemann</a> (sphalerite)</li>
     </ul>
   </aside>


### PR DESCRIPTION
This catches up on the rotation of 2022 as well as spacekookie's departure from the team.