### PR TITLE
Nixpkgs architecture team (and some small team page improvements)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ HTML = \
   community/teams/rfc-steering-committee.html \
   community/teams/security.html \
   community/teams/documentation.html \
+  community/teams/nixpkgs-architecture.html \
   demos/index.html \
   donate.html \
   download.html \

--- a/community/index.tt
+++ b/community/index.tt
@@ -270,6 +270,9 @@
       <h3>Documentation Team</h3>
       <p>Works on improving learning experience and documentation.</p>
       <a class="button -primary" href="[%root%]community/teams/documentation.html">Read more</a>
+      <h3>Nixpkgs Architecture Team</h3>
+      <p>There to solve architectural Nixpkgs issues that are too big in scope for any single person to undertake.</p>
+      <a class="button -primary" href="https://github.com/nixpkgs-architecture/">Read more</a>
     </div>
   </div>
 </section>

--- a/community/index.tt
+++ b/community/index.tt
@@ -272,7 +272,7 @@
       <a class="button -primary" href="[%root%]community/teams/documentation.html">Read more</a>
       <h3>Nixpkgs Architecture Team</h3>
       <p>There to solve architectural Nixpkgs issues that are too big in scope for any single person to undertake.</p>
-      <a class="button -primary" href="https://github.com/nixpkgs-architecture/">Read more</a>
+      <a class="button -primary" href="[%root%]community/teams/nixpkgs-architecture.html">Read more</a>
     </div>
   </div>
 </section>

--- a/community/index.tt
+++ b/community/index.tt
@@ -265,10 +265,10 @@
       <a class="button -primary" href="[%root%]community/teams/marketing.html">Read more</a>
       [% PROCESS svg path="site-styles/assets/gfx-discourse.white.svg" %]
       <h3>Moderation Team</h3>
-      <p>Moderates partitcipation on official community platforms</p>
+      <p>Moderates partitcipation on official community platforms.</p>
       <a class="button -primary" href="[%root%]community/teams/moderation.html">Read more</a>
       <h3>Documentation Team</h3>
-      <p>Works on improving learning experience and documentation</p>
+      <p>Works on improving learning experience and documentation.</p>
       <a class="button -primary" href="[%root%]community/teams/documentation.html">Read more</a>
     </div>
   </div>

--- a/community/index.tt
+++ b/community/index.tt
@@ -229,47 +229,47 @@
         nominations on each RFC, which is then responsible for accepting or
         rejecting a specific RFC.
       </p>
-      <a class="button -primary" href="[%root%]community/teams/rfc-steering-committee.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/rfc-steering-committee.html">Read more</a>
       [% PROCESS svg path="site-styles/assets/gfx-security.white.svg" %]
       <h3>Security Team</h3>
       <p>Security is a priority for the NixOS community. In addition to
         community-sourced developments, NixOS has a dedicated team, to look into
         privately reported security issues.
       </p>
-      <a class="button -primary" href="[%root%]community/teams/security.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/security.html">Read more</a>
       [% PROCESS svg path="site-styles/assets/gfx-infra.white.svg" %]
       <h3>Infrastructure Team</h3>
       <p>The responsibility of this team is to provide infrastructure for the Nix and
         NixOS community.
       </p>
-      <a class="button -primary" href="[%root%]community/teams/infrastructure.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/infrastructure.html">Read more</a>
       [% PROCESS svg path="site-styles/assets/gfx-release.white.svg" %]
       <h3>NixOS Release Team</h3>
       <p>A team that twice a year manages a release of NixOS. It is responsible
         the entire release process from setting the roadmap to uploading the
         artifacts.
       </p>
-      <a class="button -primary" href="[%root%]community/teams/nixos-release.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/nixos-release.html">Read more</a>
       [% PROCESS svg path="site-styles/assets/gfx-nixcon.white.svg" %]
       <h3>NixCon Team</h3>
       <p>A team that helps organize NixCon, a conference for the Nix and NixOS
         community.
       </p>
-      <a class="button -primary" href="[%root%]community/teams/nixcon.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/nixcon.html">Read more</a>
       [% PROCESS svg path="site-styles/assets/gfx-marketing.white.svg" %]
       <h3>Marketing Team</h3>
       <p>Its main responsibility is this website and the content on it. Apart from
         the team looks for ways to help and improve general communication of
         the project.
       </p>
-      <a class="button -primary" href="[%root%]community/teams/marketing.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/marketing.html">Read more</a>
       [% PROCESS svg path="site-styles/assets/gfx-discourse.white.svg" %]
       <h3>Moderation Team</h3>
       <p>Moderates partitcipation on official community platforms</p>
-      <a class="button -primary" href="[%root%]community/teams/moderation.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/moderation.html">Read more</a>
       <h3>Documentation Team</h3>
       <p>Works on improving learning experience and documentation</p>
-      <a class="button -primary" href="[%root%]community/teams/documentation.html">Members &amp; Contacts</a>
+      <a class="button -primary" href="[%root%]community/teams/documentation.html">Read more</a>
     </div>
   </div>
 </section>

--- a/community/teams/nixpkgs-architecture.tt
+++ b/community/teams/nixpkgs-architecture.tt
@@ -1,0 +1,97 @@
+[% WRAPPER layout.tt title="Nixpkgs Architecture Team" handlesLayout=1 %]
+
+<div class="page-title">
+  <div>
+    <a href="[% root%]community/index.html#governance-teams">Community</a>
+    <span>→</span>
+  </div>
+  <h1>Nixpkgs Architecture team</h1>
+</div>
+
+<section class="governance-description">
+  The Nixpkgs Architecture Team is there to solve architectural nixpkgs issues that are too big in scope for any single person to undertake.
+</section>
+
+<section class="governance-team">
+
+  <aside>
+    <h2>Members</h2>
+
+    <ul>
+      <li>
+        Silvan Mosberger (<a href="https://matrix.to/#/@infinisil:matrix.org">@infinisil:matrix.org</a>, <a href="https://github.com/infinisil/">@infinisil</a>, <a href="https://tweag.io">Tweag</a>)
+      </li>
+      <li>
+        Thomas Bereknyei (<a href="https://matrix.to/#/@tomberek:matrix.org">@tomberek:matrix.org</a>, <a href="https://github.com/tomberek/">@tomberek</a>, <a href="https://floxdev.com/">Flox</a>)
+      </li>
+      <li>
+        Robert Hensing (<a href="https://matrix.to/#/@roberthensing:matrix.org">@roberthensing:matrix.org</a>, <a href="https://github.com/roberth/">@roberth</a>, <a href="https://hercules-ci.com/">Hercules CI</a>)
+      </li>
+      <li>
+        Christian Höppner (<a href="https://matrix.to/#/@chris:mkaito.net">@chris:mkaito.net</a>, <a href="https://github.com/mkaito/">@mkaito</a>, <a href="https://tweag.io">Tweag</a>)
+      </li>
+      <li>
+        John Ericson (<a href="https://matrix.to/#/@Ericson2314:matrix.org">@Ericson2314:matrix.org</a>, <a href="https://github.com/Ericson2314/">@Ericson2314</a>, <a href="https://obsidian.systems/">Obsidian Systems</a>)
+      </li>
+    </ul>
+  </aside>
+
+  <h2>Motivation</h2>
+  <p>
+    Nixpkgs is arguably the most valuable resource for Nix users.
+    Its collection of packages is used by virtually every Nix user, private or commercially.
+    However, there's continuous complaints by virtually every user of nixpkgs about various aspects, like missing documentation, difficulty of contributing, inconsistent interfaces and missing features.
+    These problems need to be fixed eventually, doing nothing is not an option if Nix should be taken seriously as a universal solution for packaging.
+  </p>
+
+  <p>
+    The scale of nixpkgs has grown so considerably in recent years that it's not possible anymore for any single person to fix larger problems.
+    And even if someone does manage to find _a_ solution to a problem, there's nobody who can officially _accept_ that solution and actually merge it.
+    Over the years a number of improvements have been suggested and implemented, but most of them never made it to the finish line.
+  </p>
+
+  <p>
+    By creating a team tasked with the job of finding solutions to these issues it becomes much more feasible to actually do it.
+  </p>
+
+  <h2>Goals</h2>
+
+  <p>
+    The primary goal of this team is to make interactions with nixpkgs a joy, so that it's easy and intuitive to use, learn and contribute to.
+    The way in which this should be achieved is to fix problems in a clean, consistent and future-proof way.
+    It should be ensured that nixpkgs is a solid and trustworthy foundation for the Nix community that can be relied upon.
+  </p>
+
+  <p>
+    The process in which this should be achieved is to gather and analyze critical feedback from users to find the root causes of problems.
+    We will come up with solutions to these problems and evaluate them.
+    Eventually we'll reach consensus and decide on a solution and turn it into reality.
+    This is explained in more detail in the <a href="https://github.com/nixpkgs-architecture/#process">process</a> section over on GitHub.
+  </p>
+
+  <p>
+    Since nixpkgs is widely used by third-party code, this team needs to be very careful to ensure reasonabe backwards-compatibility.
+    Backwards incompatible changes are only in scope after a deprecation window of an appropriate duration and accompanying warning.
+  </p>
+
+  <p>
+    Check out <a href="https://github.com/orgs/nixpkgs-architecture/projects/2/views/2">this GitHub board</a> for an up-to-date list of issues that are being considered.
+    If you have an idea for an issue that should be considered, please <a href="https://github.com/nixpkgs-architecture/issues/issues/new?assignees=&amp;labels=&amp;template=issue.md&amp;title=">open a new issue</a> and it will be automatically added to the board.
+  </p>
+
+  <h2>Administration and Communication</h2>
+
+  <p>
+    Information about how to join or leave the team and the meetings can be found on the team page on GitHub.
+    Discussions are held on Matrix, Discourse and GitHub issues.
+  </p>
+  <p>
+    <a class="button" href="https://github.com/nixpkgs-architecture">GitHub Team Page</a>
+    <a class="button" href="https://matrix.to/#/#nixpkgs-architecture:nixos.org">Matrix</a>
+    <a class="button" href="https://discourse.nixos.org/c/dev/nixpkgs/44">Discourse</a>
+    <a class="button" href="https://github.com/nixpkgs-architecture/issues/issues">GitHub Issues</a>
+  </p>
+
+</section>
+
+[% END %]


### PR DESCRIPTION
Adds the [nixpkgs architecture team](https://github.com/nixpkgs-architecture/) to the team listing. Also improves the team listing a bit:
- Renames the buttons to "Read more" instead of "Members & Contacts". All of these links give you more info on the team, it's not just the people in them
- Adds some dots to sentences in the team listing for consistency