### PR TITLE
60,000 -> 80,000 packages in nixpkgs

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -92,7 +92,7 @@
       The Nix Packages collection
       <strong>(<a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a>)</strong>
       is a set of
-      <strong class="-highlighted">over 80&#160;000 packages</strong> for the Nix package manager.
+      <strong class="-highlighted">over 80&nbsp;000 packages</strong> for the Nix package manager.
     </p>
     <form method="get" action="https://search.nixos.org/packages">
       <div>

--- a/index.tt
+++ b/index.tt
@@ -92,7 +92,7 @@
       The Nix Packages collection
       <strong>(<a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a>)</strong>
       is a set of
-      <strong class="-highlighted">over 60&#160;000 packages</strong> for the Nix package manager.
+      <strong class="-highlighted">over 80&#160;000 packages</strong> for the Nix package manager.
     </p>
     <form method="get" action="https://search.nixos.org/packages">
       <div>

--- a/index.tt
+++ b/index.tt
@@ -92,7 +92,7 @@
       The Nix Packages collection
       <strong>(<a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a>)</strong>
       is a set of
-      <strong class="-highlighted">over 80&nbsp;000 packages</strong> for the Nix package manager.
+      <strong class="-highlighted">over 80&#160;000 packages</strong> for the Nix package manager.
     </p>
     <form method="get" action="https://search.nixos.org/packages">
       <div>


### PR DESCRIPTION
According to https://github.com/NixOS/nixpkgs/blob/cfaec958cc81014eae1b8f35827c7c46b4c74207/README.md there are more than 80,000 packages in the nixpkgs repository. 

(According to https://repology.org/repository/nix_stable_22_05 there are about 86K total.)