### PR TITLE
Remove Tweag sponsorship note from Christian Hoeppner

### DIFF
--- a/community/teams/nixpkgs-architecture.tt
+++ b/community/teams/nixpkgs-architecture.tt
@@ -28,7 +28,7 @@
         Robert Hensing (<a href="https://matrix.to/#/@roberthensing:matrix.org">@roberthensing:matrix.org</a>, <a href="https://github.com/roberth/">@roberth</a>, <a href="https://hercules-ci.com/">Hercules CI</a>)
       </li>
       <li>
-        Christian Höppner (<a href="https://matrix.to/#/@chris:mkaito.net">@chris:mkaito.net</a>, <a href="https://github.com/mkaito/">@mkaito</a>, <a href="https://tweag.io">Tweag</a>)
+        Christian Höppner (<a href="https://matrix.to/#/@chris:mkaito.net">@chris:mkaito.net</a>, <a href="https://github.com/mkaito/">@mkaito</a>)
       </li>
       <li>
         John Ericson (<a href="https://matrix.to/#/@Ericson2314:matrix.org">@Ericson2314:matrix.org</a>, <a href="https://github.com/Ericson2314/">@Ericson2314</a>, <a href="https://obsidian.systems/">Obsidian Systems</a>)


### PR DESCRIPTION
I no longer work for Tweag.