### PR TITLE
download.tt: Expose aarch64-linux ISOs for 22.11

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -195,13 +195,21 @@ nix-env (Nix) 2.3.15</pre>
 
         <ul class="download-buttons">
           <li>
-            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso">Download (GNOME, 64bit)</a>
+            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso">Download (GNOME, 64-bit Intel/AMD, x86_64)</a>
             <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso.sha256">(SHA-256)</a>
             <span class="label -success">Recommended for most users</span>
           </li>
           <li>
-            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso">Download (Plasma Desktop, 64bit)</a>
+            <a href="[%prefix%]/latest-nixos-gnome-aarch64-linux.iso">Download (GNOME, 64-bit ARM, aarch64)</a>
+            <a href="[%prefix%]/latest-nixos-gnome-aarch64-linux.iso.sha256">(SHA-256)</a>
+          </li>
+          <li>
+            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso">Download (Plasma Desktop, 64-bit Intel/AMD, x86_64)</a>
             <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso.sha256">(SHA-256)</a>
+          </li>
+          <li>
+            <a href="[%prefix%]/latest-nixos-plasma5-aarch64-linux.iso">Download (Plasma Desktop, 64-bit ARM, aarch64)</a>
+            <a href="[%prefix%]/latest-nixos-plasma5-aarch64-linux.iso.sha256">(SHA-256)</a>
           </li>
         </ul>
 
@@ -218,11 +226,15 @@ nix-env (Nix) 2.3.15</pre>
 
         <ul class="download-buttons">
           <li>
-            <a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso">Download (64bit)</a>
+            <a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso">Download (64-bit Intel/AMD, x86_64)</a>
             <a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso.sha256">(SHA-256)</a>
           </li>
+	  <li>
+            <a href="[%prefix%]/latest-nixos-minimal-aarch64-linux.iso">Download (64-bit Intel/AMD, aarch64)</a>
+            <a href="[%prefix%]/latest-nixos-minimal-aarch64-linux.iso.sha256">(SHA-256)</a>
+          </li>
           <li>
-            <a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso">Download (32bit)</a>
+            <a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso">Download (32-bit Intel/AMD, i686)</a>
             <a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso.sha256">(SHA-256)</a>
           </li>
         </ul>

--- a/download.tt
+++ b/download.tt
@@ -195,20 +195,20 @@ nix-env (Nix) 2.3.15</pre>
 
         <ul class="download-buttons">
           <li>
-            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso">Download (GNOME, 64-bit Intel/AMD, x86_64)</a>
+            <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso">Download (GNOME, 64-bit Intel/AMD)</a>
             <a href="[%prefix%]/latest-nixos-gnome-x86_64-linux.iso.sha256">(SHA-256)</a>
             <span class="label -success">Recommended for most users</span>
           </li>
           <li>
-            <a href="[%prefix%]/latest-nixos-gnome-aarch64-linux.iso">Download (GNOME, 64-bit ARM, aarch64)</a>
+            <a href="[%prefix%]/latest-nixos-gnome-aarch64-linux.iso">Download (GNOME, 64-bit ARM)</a>
             <a href="[%prefix%]/latest-nixos-gnome-aarch64-linux.iso.sha256">(SHA-256)</a>
           </li>
           <li>
-            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso">Download (Plasma Desktop, 64-bit Intel/AMD, x86_64)</a>
+            <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso">Download (Plasma Desktop, 64-bit Intel/AMD)</a>
             <a href="[%prefix%]/latest-nixos-plasma5-x86_64-linux.iso.sha256">(SHA-256)</a>
           </li>
           <li>
-            <a href="[%prefix%]/latest-nixos-plasma5-aarch64-linux.iso">Download (Plasma Desktop, 64-bit ARM, aarch64)</a>
+            <a href="[%prefix%]/latest-nixos-plasma5-aarch64-linux.iso">Download (Plasma Desktop, 64-bit ARM)</a>
             <a href="[%prefix%]/latest-nixos-plasma5-aarch64-linux.iso.sha256">(SHA-256)</a>
           </li>
         </ul>
@@ -226,15 +226,15 @@ nix-env (Nix) 2.3.15</pre>
 
         <ul class="download-buttons">
           <li>
-            <a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso">Download (64-bit Intel/AMD, x86_64)</a>
+            <a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso">Download (64-bit Intel/AMD)</a>
             <a href="[%prefix%]/latest-nixos-minimal-x86_64-linux.iso.sha256">(SHA-256)</a>
           </li>
 	  <li>
-            <a href="[%prefix%]/latest-nixos-minimal-aarch64-linux.iso">Download (64-bit Intel/AMD, aarch64)</a>
+            <a href="[%prefix%]/latest-nixos-minimal-aarch64-linux.iso">Download (64-bit Intel/AMD)</a>
             <a href="[%prefix%]/latest-nixos-minimal-aarch64-linux.iso.sha256">(SHA-256)</a>
           </li>
           <li>
-            <a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso">Download (32-bit Intel/AMD, i686)</a>
+            <a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso">Download (32-bit Intel/AMD)</a>
             <a href="[%prefix%]/latest-nixos-minimal-i686-linux.iso.sha256">(SHA-256)</a>
           </li>
         </ul>
@@ -248,7 +248,7 @@ nix-env (Nix) 2.3.15</pre>
           well as <strong>the VirtualBox guest additions</strong>.</p>
         <ul class="download-buttons">
           <li>
-            <a href="[%prefix%]/latest-nixos-x86_64-linux.ova">Download (64bit)</a>
+            <a href="[%prefix%]/latest-nixos-x86_64-linux.ova">Download (64-bit)</a>
             <a href="[%prefix%]/latest-nixos-x86_64-linux.ova.sha256">(SHA-256)</a>
           </li>
         </ul>


### PR DESCRIPTION
The aarch64-linux ISOs are part of the nixos-unstable and unstable-small jobsets and exposed through the nixos-channel-scripts.

This means they will be available for the upcoming NixOS 22.11 release and can be linked from the homepage.