### PR TITLE
fix link to Nix language tutorial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ HTML = \
   download.html \
   explore.html \
   guides/how-nix-works.html \
+  guides/nix-language.html \
   guides/ad-hoc-developer-environments.html \
   guides/towards-reproducibility-pinning-nixpkgs.html \
   guides/declarative-and-reproducible-developer-environments.html \

--- a/scripts/copy-nix-dev-tutorials.sh
+++ b/scripts/copy-nix-dev-tutorials.sh
@@ -4,6 +4,7 @@ set -e
 
 pages=(
   # "tutorials/install-nix.html" # Not needed since this is part of Download page
+  "tutorials/nix-language.html"
   "tutorials/ad-hoc-developer-environments.html"
   "tutorials/towards-reproducibility-pinning-nixpkgs.html"
   "tutorials/declarative-and-reproducible-developer-environments.html"


### PR DESCRIPTION
tracking nix.dev this way doesn't scale and has to be reworked if we
want to ramp up tutorials and guides on nix.dev

@LucPerkins @bryanhonof 