### PR TITLE
download: fix MacOS manual link

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -85,7 +85,7 @@
         <p>
           We believe we have ironed out how to cleanly support the read-only
           root on modern macOS. Please
-          <a href="https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation">consult the manual</a>
+          <a href="[%nixManual%]/installation/installing-binary.html#macos-installation">consult the manual</a>
           on details what the installation script does.
         </p>
       </article>


### PR DESCRIPTION
Currently the link on read-only root directs people to the multi-user installation instructions. Where-as the section on "MacOS Installation" is the part where it actually explains about read-only root.

This PR changes the link so that it directs to "MacOS Installation"