### PR TITLE
flake.nix: Don't print the instructions on stdout

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -180,15 +180,15 @@ rec {
             rm -f site-styles/common-styles
             ln -s ${nixos-common-styles.packages."${system}".commonStyles} site-styles/common-styles
 
-            echo ""
-            echo "  To start developing run:"
-            echo "      serve"
-            echo ""
-            echo "  and go to the following URL in your browser:"
-            echo "      https://127.0.0.1:8000/"
-            echo ""
-            echo "  It will rebuild the website on each change."
-            echo ""
+            >&2 echo ""
+            >&2 echo "  To start developing run:"
+            >&2 echo "      serve"
+            >&2 echo ""
+            >&2 echo "  and go to the following URL in your browser:"
+            >&2 echo "      https://127.0.0.1:8000/"
+            >&2 echo ""
+            >&2 echo "  It will rebuild the website on each change."
+            >&2 echo ""
           '';
         };
       };


### PR DESCRIPTION
Otherwise they get [added](https://github.com/NixOS/nixos-homepage/blob/d5c136aed7f9d2d72bef29b912c1a7514d8940fb/scripts/update.sh#L15) to the live site:

![20221201_17h46m14s_grim](https://user-images.githubusercontent.com/2189609/205189362-d2ef9d49-d326-4de5-b908-7c1f2148a2f8.png)

I didn't update the page to avoid a merge conflict with the automated action.