### PR TITLE
Migrate the stable nixpkgs input to nixos-22.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,16 +282,16 @@
     },
     "released-nixpkgs-stable": {
       "locked": {
-        "lastModified": 1670108384,
-        "narHash": "sha256-hrOa+NxkViveTetMqo9GnDLxPK3ZhIqa76JOCtc4/jw=",
+        "lastModified": 1670009809,
+        "narHash": "sha256-yt/dQ32Vz4WenDLu4XeHbnXFxiHbTcnU0WwiLW5Ce6c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5bab4e401ef58bba4c5081dd379ffa69072c17fb",
+        "rev": "660e7737851506374da39c0fa550c202c824a17c",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "release-22.11",
+        "ref": "nixos-22.11",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@ rec {
 
   # These inputs are used for the manuals and release artifacts
   inputs.released-nixpkgs-unstable = { url = "nixpkgs/nixos-unstable"; };
-  inputs.released-nixpkgs-stable = { url = "nixpkgs/release-22.11"; };
+  inputs.released-nixpkgs-stable = { url = "nixpkgs/nixos-22.11"; };
   inputs.released-nix-unstable = { url = "github:nixos/nix/master"; };
   inputs.released-nix-stable = { url = "github:nixos/nix/latest-release"; };
   inputs.nix-pills = { url = "github:NixOS/nix-pills"; flake = false; };


### PR DESCRIPTION
I used release-22.11 in the nixos 22.11 announcement, because nixos-22.11 hadn't progressed far enough yet. Let's revert back to the cached version now that it has caught up.