### PR TITLE
Update release wiki link

### DIFF
--- a/community/teams/nixos-release.tt
+++ b/community/teams/nixos-release.tt
@@ -43,8 +43,8 @@
   <h2>Release process</h2>
   <p>
     More information can be found in
-    <a href="https://nixos.org/nixos/manual/index.html#release-managers">
-      the nixos manual.
+    <a href="https://nixos.github.io/release-wiki/Home.html">
+      the NixOS Release Wiki.
     </a>
   </p>
 


### PR DESCRIPTION
Update link from it used to be located on the release manual in nixpkgs to the current rendered release wiki markdown repo.