### PR TITLE
stepping back from documentation team

### DIFF
--- a/community/teams/documentation.tt
+++ b/community/teams/documentation.tt
@@ -23,10 +23,6 @@
         Nix advocate, <a href="https://determinate.systems">Determinate Systems</a>
       </li>
       <li>
-        Jörg Thalheim (<a href="https://discourse.nixos.org/u/Mic92">@Mic92</a>)<br/>
-        <a href="https://nixos.wiki">NixOS Wiki</a> maintainer
-      </li>
-      <li>
         Domen Kožar (<a href="https://discourse.nixos.org/u/domenkozar">@domenkozar</a>)<br/>
         <a href="https://nix.dev">nix.dev</a> author, <a href="https://cachix.org">Cachix</a>
       </li>


### PR DESCRIPTION
Thanks for all the work! I see myself already be saturated with writing documentation for my own projects. I fail to keep track with all the work that the documentation team and the community is doing and hence I feel like I do not have much to contribute to the regular meetings.

In case someone wonders, this is not related to
https://discourse.nixos.org/t/parting-from-the-documentation-team/24900 in any way. I have not followed what happend there and this decision to step back has been already made before.