### PR TITLE
fix self-reference link inside a guide

### DIFF
--- a/scripts/copy-nix-dev-tutorials.sh
+++ b/scripts/copy-nix-dev-tutorials.sh
@@ -43,7 +43,7 @@ for page in "${pages[@]}"; do
     | sed 's|<a class="reference internal" href="../glossary.html#term-attribute-name"><span class="xref std std-term">attribute name</span></a>|attribute name|g' \
     | sed 's|<a class="reference internal" href="../glossary.html#term-package-name"><span class="xref std std-term">package name</span></a>|package name|g' \
     | sed 's|<a class="reference internal" href="../glossary.html#term-reproducible"><span class="xref std std-term">reproducible</span></a>|reproducible|g' \
-    | sed 's|../reference/pinning-nixpkgs.html#ref-pinning-nixpkgs|towards-reproducibility-pinning-nixpkgs.html|g' \
+    | sed 's|../reference/pinning-nixpkgs.html#ref-pinning-nixpkgs|https://nix.dev/reference/pinning-nixpkgs#ref-pinning-nixpkgs|g' \
       > "$temp"
 
   echo "[% WRAPPER atHead %] <link rel=\"canonical\" href=\"https://nix.dev/$page\" /> [% END %]" > $target


### PR DESCRIPTION
The "Next steps" section of https://nixos.org/guides/towards-reproducibility-pinning-nixpkgs.html contains a link to itself, ie to
https://nixos.org/guides/towards-reproducibility-pinning-nixpkgs.html

This is wrong. If you go to the original article at https://nix.dev/tutorials/towards-reproducibility-pinning-nixpkgs you can see that the link actually points to https://nix.dev/reference/pinning-nixpkgs.html#ref-pinning-nixpkgs

Afaik, this article doesn't exist on nixos.org, so I'm fixing this by linking the original article on nix.dev