### PR TITLE
Add netlify redirect rule.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -173,6 +173,12 @@
   force = true
 
 [[redirects]]
+  from = "/nixos/manual/unstable/*"
+  to = "/manual/nixos/stable/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
   from = "/nixos/manual/*"
   to = "/manual/nixos/stable/:splat"
   status = 302


### PR DESCRIPTION
This is an effort to fix https://github.com/NixOS/nixos-homepage/issues/698

My theory of what is going on:
- the redirects are supposed to redirect from `unstable` URLs to `stable`
- the failure mentioned in the issue is because `unstable` is being captured and passed into the URL to be redirected to, via the `splat`
- since the first matching rule is applied (only), I added a more specific rule above the rule which I think caused the problem

**It seems like we need the netlify cli tool for netlify.toml redirect rules to take effect in development.**