### PR TITLE
doc team: Remove Luc, readd (mistakenly removed) Valentin

### DIFF
--- a/community/teams/documentation.tt
+++ b/community/teams/documentation.tt
@@ -19,8 +19,8 @@
 
     <ul>
       <li>
-        Luc Perkins (<a href="https://discourse.nixos.org/u/lucperkins">@lucperkins</a>) (lead until 2023-01-31)<br/>
-        Nix advocate, <a href="https://determinate.systems">Determinate Systems</a>
+        Valentin Gagarin (<a href="https://discourse.nixos.org/u/fricklerhandwerk">@fricklerhandwerk</a>)<br/>
+        Nix documentarian, <a href="https://tweag.io">Tweag</a>
       </li>
       <li>
         Silvan Mosberger (<a href="https://discourse.nixos.org/u/infinisil">@infinisil</a>)<br/>


### PR DESCRIPTION
Valentin never left the docs team, but he was mistakenly removed in https://github.com/NixOS/nixos-homepage/pull/922.

Luc is not team lead anymore and effectively stepped down from the team after the drama from
https://discourse.nixos.org/t/parting-from-the-documentation-team/24900, see https://matrix.to/#/!avYyleMexqjFHoqrME:nixos.org/$QYprG8cyv4zbj3qk9lMeJm9_z07xbjknsWfQ6T2Zs6w