### PR TITLE
Explicitly mention sponsorship for the docs team

### DIFF
--- a/community/teams/documentation.tt
+++ b/community/teams/documentation.tt
@@ -20,11 +20,11 @@
     <ul>
       <li>
         Valentin Gagarin (<a href="https://discourse.nixos.org/u/fricklerhandwerk">@fricklerhandwerk</a>)<br/>
-        Nix documentarian, <a href="https://tweag.io">Tweag</a>
+        Nix documentarian, sponsored by <a href="https://tweag.io">Tweag</a>
       </li>
       <li>
         Silvan Mosberger (<a href="https://discourse.nixos.org/u/infinisil">@infinisil</a>)<br/>
-        <a href="https://nixpkgs.org">Nixpkgs</a> maintainer, <a href="https://tweag.io">Tweag</a>
+        <a href="https://nixpkgs.org">Nixpkgs</a> maintainer, sponsored by <a href="https://tweag.io">Tweag</a>
       </li>
     </ul>
 


### PR DESCRIPTION
Previously it was unclear if the company was just who you're part of, or actually sponsored

Ping @fricklerhandwerk, discussed in this week's doc team meeting