### PR TITLE
documentation team: disclose affiliation precisely

### DIFF
--- a/community/teams/documentation.tt
+++ b/community/teams/documentation.tt
@@ -20,7 +20,7 @@
     <ul>
       <li>
         Valentin Gagarin (<a href="https://discourse.nixos.org/u/fricklerhandwerk">@fricklerhandwerk</a>)<br/>
-        Nix documentarian, sponsored by <a href="https://tweag.io">Tweag</a>
+        Nix documentarian, sponsored by <a href="https://antithesis.com/">Antithesis</a> via <a href="https://tweag.io">Tweag</a>
       </li>
       <li>
         Silvan Mosberger (<a href="https://discourse.nixos.org/u/infinisil">@infinisil</a>)<br/>


### PR DESCRIPTION
employment and funding in the consulting space are distinct things, and
in this setup there are indeed two principals one has to know to have
the correct impression of affiliations

@infinisil for double-check