### PR TITLE
add redirect to catch removed Nix manual page (basic package management)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -149,6 +149,12 @@
   force = true
 
 [[redirects]]
+  from = "/manual/nix/:version/package-management/basic-package-mgmt.html"
+  to = "/manual/nix/:version/command-ref/nix-env.html"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/manual/nixpkgs"
   to = "/manual/nixpkgs/stable"
   status = 302


### PR DESCRIPTION
blocked by https://github.com/NixOS/nix/pull/7974