### PR TITLE
Link to installation section

### DIFF
--- a/download.tt
+++ b/download.tt
@@ -194,7 +194,10 @@
 
         <p>The minimal installation ISO image <strong>does not contain the
             graphical user interface</strong>, and is therefore a lot smaller.
-          You have to <strong>run the installer from the console</strong>. It
+          You have to
+          <a href="[%root%]manual/nixos/stable/index.html#ch-installation">
+            <strong>run the installer from the console</strong>
+          </a>. It
           contains a number of rescue tools.</p>
 
         <ul class="download-buttons">


### PR DESCRIPTION
We should not only tell users that they need to run the installer, we also need to tell them how to. Thus, link to the install section of the manual here.

---

Closes #1013 
CC @fricklerhandwerk 