### PR TITLE
Fix the broken `Building Your Own NixOS CD` link on Learn page

### DIFF
--- a/learn.tt
+++ b/learn.tt
@@ -199,7 +199,7 @@
           <li><a href="[%root%]manual/nixos/stable/#sec-writing-modules">Writing NixOS Modules</a></li>
           <li><a href="[%root%]manual/nixos/stable/#sec-writing-documentation">Writing NixOS Documentation</a></li>
           <li><a href="[%root%]manual/nixos/stable/#sec-nixos-tests">Writing NixOS Tests</a></li>
-          <li><a href="[%root%]manual/nixos/stable/#sec-building-cd">Building Your Own NixOS CD</a></li>
+          <li><a href="[%root%]manual/nixos/stable/#sec-building-image">Building Your Own NixOS CD</a></li>
         </ul>
         <a href="[%root%]manual/nixos/stable">Full NixOS Manual</a>
       </div>


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixos-homepage/issues/1019 