### PR TITLE
community: add top/bottom margin to buttons (closes #1050)

### DIFF
--- a/site-styles/pages/community.less
+++ b/site-styles/pages/community.less
@@ -606,6 +606,11 @@
       }
     }
   });
+
+  .button {
+    margin-top: 0.25*@gutter;
+    margin-bottom: 0.25*@gutter;
+  }
 }
 
 .community-commercial-support {


### PR DESCRIPTION
This prevents the bottoms and tops of buttons on multiple rows touching when using a narrow-ish viewport.

Closes #1050 (see for original screenshots).

With a single-column viewport:

<img width="612" alt="Single-columm viewport after" src="https://github.com/NixOS/nixos-homepage/assets/3880346/31081e97-46e9-4f08-9f46-15ffafe17542">

With a multi-column viewport:

<img width="926" alt="Multi-column viewport after" src="https://github.com/NixOS/nixos-homepage/assets/3880346/29479c3c-7082-4244-b075-c573d66208e6">
