### PR TITLE
Use client-side shuffle on "Commercial support" page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ index.html: blog/announcements-rss.xml blog/index.html
 community/commercial-support.html: community/commercial-support.html.in
 
 community/commercial-support.html.in: community/commercial-support.toml
-	shuffle-commercial-providers --input community/commercial-support.toml > $@
+	update-commercial-providers --input community/commercial-support.toml > $@
 
 
 ### Check

--- a/community/commercial-support.html.in
+++ b/community/commercial-support.html.in
@@ -1,18 +1,5 @@
 
     <li>
-      <a href="https://tweag.io/">
-        <div>
-          <img alt="Tweag" src="/community/commercial-support-logos/tweag.svg" />
-        </div>
-        <h2>Tweag</h2>
-        <ul><li>Remote</li><li>Paris, France</li><li>London, UK</li><li>Zurich, Switzerland</li></ul>
-        We enable deep-tech startups to achieve their vision, from research to product
-delivery. Top contributor to Nix and this website.
-
-      </a>
-    </li>
-
-    <li>
       <a href="http://blackriversoft.com/">
         <div>
           <img alt="Black River Software" src="/community/commercial-support-logos/black-river-software.png" />
@@ -21,124 +8,6 @@ delivery. Top contributor to Nix and this website.
         <ul><li>Ohio, USA</li></ul>
         Black River Software offers custom software development, software architecture
 consulting, and build and deployment engineering services.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://floxdev.com">
-        <div>
-          <img alt="flox" src="/community/commercial-support-logos/flox.png" />
-        </div>
-        <h2>flox</h2>
-        <ul><li>Remote</li><li>San Francisco</li><li>London</li></ul>
-        flox is a platform for building, sharing, and collaborating across the entire
-development lifecycle.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://immutablesolutions.com/">
-        <div>
-          <img alt="Immutable Solutions" src="/community/commercial-support-logos/immutable-solutions.png" />
-        </div>
-        <h2>Immutable Solutions</h2>
-        <ul><li>Sweden</li></ul>
-        Nix specialists helping companies design, develop and deploy systems in a
-declarative fashion.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://obsidian.systems">
-        <div>
-          <img alt="Obsidian Systems" src="/community/commercial-support-logos/obsidian-systems.svg" />
-        </div>
-        <h2>Obsidian Systems</h2>
-        <ul><li>New York, USA</li></ul>
-        Software consultancy specializing in Haskell, Nix, curiosity, and innovation.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://www.fivebinaries.com/">
-        <div>
-          <img alt="five binaries" src="/community/commercial-support-logos/5inaries.png" />
-        </div>
-        <h2>five binaries</h2>
-        <ul><li>Tallinn, Estonia</li><li>Prague, Czech Republic</li></ul>
-        Five Binaries are an infrastructure development company focused on creating
-customized highly reliable solutions for blockchain-powered industries.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://nix.how">
-        <div>
-          <img alt="Nix.How" src="/community/commercial-support-logos/nix-how.png" />
-        </div>
-        <h2>Nix.How</h2>
-        <ul><li>Remote</li><li>United Kingdom</li></ul>
-        Nix experts specialising in converting legacy infrastructure to a Nix/NixOS
-methodology and workflow
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://arnout.engelen.eu">
-        <div>
-          <img alt="Engelen Open Source" src="/community/commercial-support-logos/engelen-open-source.png" />
-        </div>
-        <h2>Engelen Open Source</h2>
-        <ul><li>Remote</li><li>Netherlands</li></ul>
-        Arnout 'raboof' Engelen is an independent consultant available for
-support and small- to medium-sized projects around Nix and Open Source.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://serokell.io/">
-        <div>
-          <img alt="Serokell" src="/community/commercial-support-logos/serokell.png" />
-        </div>
-        <h2>Serokell</h2>
-        <ul><li>Remote</li><li>Tallinn, Estonia</li></ul>
-        Serokell is a custom software engineering company that creates innovative
-solutions for complex problems. We do software development, consulting, and
-auditing.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://nixcademy.com">
-        <div>
-          <img alt="Nixcademy" src="/community/commercial-support-logos/nixcademy.svg" />
-        </div>
-        <h2>Nixcademy</h2>
-        <ul><li>Remote</li><li>Germany</li></ul>
-        Elevate your organization's expertise with Nix and NixOS through our comprehensive corporate training classes, personalized mentoring, and expert consulting services.
-Empower your team with the latest knowledge and best practices.
-
-      </a>
-    </li>
-
-    <li>
-      <a href="https://helsinki-systems.de">
-        <div>
-          <img alt="Helsinki Systems" src="/community/commercial-support-logos/helsinki-systems.png" />
-        </div>
-        <h2>Helsinki Systems</h2>
-        <ul><li>Stuttgart, Germany</li></ul>
-        Your partner for hosting, networks and IT solutions running on NixOS. We have
-multiple years of NixOS and decades of Linux experience to aid your NixOS
-integration and administration.
 
       </a>
     </li>
@@ -158,6 +27,19 @@ collaborators.
     </li>
 
     <li>
+      <a href="https://arnout.engelen.eu">
+        <div>
+          <img alt="Engelen Open Source" src="/community/commercial-support-logos/engelen-open-source.png" />
+        </div>
+        <h2>Engelen Open Source</h2>
+        <ul><li>Remote</li><li>Netherlands</li></ul>
+        Arnout 'raboof' Engelen is an independent consultant available for
+support and small- to medium-sized projects around Nix and Open Source.
+
+      </a>
+    </li>
+
+    <li>
       <a href="https://www.enlambda.com/">
         <div>
           <img alt="Enlambda" src="/community/commercial-support-logos/enlambda.png" />
@@ -170,6 +52,45 @@ collaborators.
     </li>
 
     <li>
+      <a href="https://www.fivebinaries.com/">
+        <div>
+          <img alt="five binaries" src="/community/commercial-support-logos/5inaries.png" />
+        </div>
+        <h2>five binaries</h2>
+        <ul><li>Tallinn, Estonia</li><li>Prague, Czech Republic</li></ul>
+        Five Binaries are an infrastructure development company focused on creating
+customized highly reliable solutions for blockchain-powered industries.
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://helsinki-systems.de">
+        <div>
+          <img alt="Helsinki Systems" src="/community/commercial-support-logos/helsinki-systems.png" />
+        </div>
+        <h2>Helsinki Systems</h2>
+        <ul><li>Stuttgart, Germany</li></ul>
+        Your partner for hosting, networks and IT solutions running on NixOS. We have
+multiple years of NixOS and decades of Linux experience to aid your NixOS
+integration and administration.
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://nixos.mayflower.consulting">
+        <div>
+          <img alt="Mayflower" src="/community/commercial-support-logos/mayflower.png" />
+        </div>
+        <h2>Mayflower</h2>
+        <ul><li>Munich, Germany</li><li>Berlin, Germany</li><li>Würzburg, Germany</li></ul>
+        We are Mayflower. We build infrastructure. Declarative &amp; reproducible.
+
+      </a>
+    </li>
+
+    <li>
       <a href="https://www.numtide.com/">
         <div>
           <img alt="Numtide Ltd" src="/community/commercial-support-logos/numtide.png" />
@@ -177,6 +98,31 @@ collaborators.
         <h2>Numtide Ltd</h2>
         <ul><li>Switzerland</li><li>Remote</li></ul>
         Numtide is a Nix and DevOps consulting company. We help our customers with declarative development, cloud and bare-metal infrastructures.
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://nixcademy.com">
+        <div>
+          <img alt="Nixcademy" src="/community/commercial-support-logos/nixcademy.svg" />
+        </div>
+        <h2>Nixcademy</h2>
+        <ul><li>Remote</li><li>Germany</li></ul>
+        Elevate your organization's expertise with Nix and NixOS through our comprehensive corporate training classes, personalized mentoring, and expert consulting services.
+Empower your team with the latest knowledge and best practices.
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://obsidian.systems">
+        <div>
+          <img alt="Obsidian Systems" src="/community/commercial-support-logos/obsidian-systems.svg" />
+        </div>
+        <h2>Obsidian Systems</h2>
+        <ul><li>New York, USA</li></ul>
+        Software consultancy specializing in Haskell, Nix, curiosity, and innovation.
 
       </a>
     </li>
@@ -196,13 +142,67 @@ Over budget? Not working properly? Growing with bugs? We can help.
     </li>
 
     <li>
-      <a href="https://nixos.mayflower.consulting">
+      <a href="https://serokell.io/">
         <div>
-          <img alt="Mayflower" src="/community/commercial-support-logos/mayflower.png" />
+          <img alt="Serokell" src="/community/commercial-support-logos/serokell.png" />
         </div>
-        <h2>Mayflower</h2>
-        <ul><li>Munich, Germany</li><li>Berlin, Germany</li><li>Würzburg, Germany</li></ul>
-        We are Mayflower. We build infrastructure. Declarative &amp; reproducible.
+        <h2>Serokell</h2>
+        <ul><li>Remote</li><li>Tallinn, Estonia</li></ul>
+        Serokell is a custom software engineering company that creates innovative
+solutions for complex problems. We do software development, consulting, and
+auditing.
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://tweag.io/">
+        <div>
+          <img alt="Tweag" src="/community/commercial-support-logos/tweag.svg" />
+        </div>
+        <h2>Tweag</h2>
+        <ul><li>Remote</li><li>Paris, France</li><li>London, UK</li><li>Zurich, Switzerland</li></ul>
+        We enable deep-tech startups to achieve their vision, from research to product
+delivery. Top contributor to Nix and this website.
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://immutablesolutions.com/">
+        <div>
+          <img alt="Immutable Solutions" src="/community/commercial-support-logos/immutable-solutions.png" />
+        </div>
+        <h2>Immutable Solutions</h2>
+        <ul><li>Sweden</li></ul>
+        Nix specialists helping companies design, develop and deploy systems in a
+declarative fashion.
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://nix.how">
+        <div>
+          <img alt="Nix.How" src="/community/commercial-support-logos/nix-how.png" />
+        </div>
+        <h2>Nix.How</h2>
+        <ul><li>Remote</li><li>United Kingdom</li></ul>
+        Nix experts specialising in converting legacy infrastructure to a Nix/NixOS
+methodology and workflow
+
+      </a>
+    </li>
+
+    <li>
+      <a href="https://floxdev.com">
+        <div>
+          <img alt="flox" src="/community/commercial-support-logos/flox.png" />
+        </div>
+        <h2>flox</h2>
+        <ul><li>Remote</li><li>San Francisco</li><li>London</li></ul>
+        flox is a platform for building, sharing, and collaborating across the entire
+development lifecycle.
 
       </a>
     </li>

--- a/community/commercial-support.tt
+++ b/community/commercial-support.tt
@@ -15,7 +15,7 @@
     <a href="https://github.com/NixOS/nixos-homepage/edit/master/community/commercial-support.toml">submit a pull
       request</a>
     to add your company
-    (the list is randomized on each website update).
+    (the list is randomized each hour).
   </p>
   <ul>
     [% INSERT "community/commercial-support.html.in" %]

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+(import (fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz") {
   src = builtins.fetchGit ./.;
 }).defaultNix

--- a/flake.nix
+++ b/flake.nix
@@ -81,8 +81,8 @@ rec {
         serve =
           mkPyScript (with pkgs.python3Packages; [ click livereload ]) "serve";
 
-        shuffle_commercial_providers =
-          mkPyScript (with pkgs.python3Packages; [ click toml ]) "shuffle-commercial-providers";
+        update_providers =
+          mkPyScript (with pkgs.python3Packages; [ click toml ]) "update-commercial-providers";
 
         update_blog =
           mkPyScript (with pkgs.python3Packages; [ aiohttp click feedparser cchardet ]) "update-blog";
@@ -120,8 +120,8 @@ rec {
                 perlPackages.TemplateToolkit
                 perlPackages.XMLSimple
                 serve
-                shuffle_commercial_providers
                 update_blog
+                update_providers
                 xhtml1
                 which
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -92,7 +92,7 @@ rec {
 
         checks.build = defaultPackage;
 
-        packages = rec {
+        packages = {
           homepage = pkgs.stdenv.mkDerivation {
             name = "nixos-homepage-${self.lastModifiedDate}";
 

--- a/js/nixos-site.js
+++ b/js/nixos-site.js
@@ -1,3 +1,25 @@
+$.fn.shuffleChildren = function() {
+  $.each(this.get(), function(index, el) {
+      var random = function(s = Date.now()) {
+        return function() {
+            s = Math.sin(s) * 10000;
+
+            return s - Math.floor(s);
+        };
+      };
+
+      var $el = $(el);
+      var $find = $el.children();
+
+      $find.sort(function() {
+          return 0.5 - random((new Date).getHours());
+      });
+
+      $el.empty();
+      $find.appendTo($el);
+  });
+};
+
 $(function () {
   // Special "pseudo-global" variable to track whether we are synthetically
   // activating an event. In that case some semantics are different.
@@ -324,4 +346,5 @@ $(function () {
   // This way tabs and panes are active as intended.
   handleNavigation();
 
+  $("section.community-commercial-support > ul").shuffleChildren();
 });

--- a/js/nixos-site.js
+++ b/js/nixos-site.js
@@ -1,22 +1,22 @@
-$.fn.shuffleChildren = function() {
+// FisherYates implementation
+$.fn.shuffleChildren = function(seedParam = Date.now()) {
+  var randomish = function(s) {
+    s = Math.sin(s) * 10000;
+    return s - Math.floor(s);
+  };
+
   $.each(this.get(), function(index, el) {
-      var random = function(s = Date.now()) {
-        return function() {
-            s = Math.sin(s) * 10000;
+    var $el = $(el);
+    var $find = $el.children();
+    var len = $find.length;
+    var seed = randomish(seedParam);
 
-            return s - Math.floor(s);
-        };
-      };
+    while (--len) {
+      let randIndex = Math.floor(seed * (len + 1));
+      [$find[randIndex], $find[len]] = [$find[len], $find[randIndex]];
+    }
 
-      var $el = $(el);
-      var $find = $el.children();
-
-      $find.sort(function() {
-          return 0.5 - random((new Date).getHours());
-      });
-
-      $el.empty();
-      $find.appendTo($el);
+    $el.empty().append($find);
   });
 };
 
@@ -346,5 +346,5 @@ $(function () {
   // This way tabs and panes are active as intended.
   handleNavigation();
 
-  $("section.community-commercial-support > ul").shuffleChildren();
+  $("section.community-commercial-support > ul").shuffleChildren((new Date).getHours());
 });

--- a/scripts/update-commercial-providers.py
+++ b/scripts/update-commercial-providers.py
@@ -1,5 +1,4 @@
 import click
-import random
 import toml
 
 TEMPLATE = """
@@ -21,8 +20,6 @@ def main(input):
 
     with open(input) as f:
         providers = toml.load(f)["commercial-provider"]
-
-    random.shuffle(providers)
 
     for provider in providers:
         provider["name"] = provider["name"][:50]

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -11,8 +11,5 @@ nix flake lock \
   --update-input nix-pills \
   --update-input nix-dev
 
-echo "Shuffle commercial providers ..."
-nix develop --command shuffle-commercial-providers --input community/commercial-support.toml > community/commercial-support.html.in
-
 echo "Updating blog..."
 nix develop --command update-blog --output-dir blog/


### PR DESCRIPTION
This PR:

- Is related to #854 
- Add a Javascript shuffling the section, the shuffling is updated every hour
- Rename the script `shuffle-commercial-providers` into `update-commercial-providers`

Additional things:
- JSFiddle script: https://jsfiddle.net/gb63joLy/

:warning: There will be conflict with the file `community/commercial-support.html.in` during the lifetime of this PR because that file gets updated hourly randomly... hence the conflicts. If it gets accepted, I'll rebase it properly.