### PR TITLE
Add "Reproducible Builds Status" to footer

### DIFF
--- a/layout.tt
+++ b/layout.tt
@@ -104,6 +104,7 @@ BLOCK navigationLink %]
             <li><a href="https://status.nixos.org/">Channel Status</a></li>
             <li><a href="https://search.nixos.org/packages">Packages search</a></li>
             <li><a href="https://search.nixos.org/options">Options search</a></li>
+            <li><a href="https://reproducible.nixos.org/">Reproducible Builds Status</a></li>
             <li><a href="[% root %]community/teams/security.html">Security</a></li>
           </ul>
         </section>


### PR DESCRIPTION
So interested people find it

Not built and tested if it breaks the layout. Maybe text is too long.