### PR TITLE
add marketing team mission and strategy

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -277,9 +277,9 @@
 
       [% PROCESS svg path="site-styles/assets/gfx-marketing.white.svg" %]
       <h3>Marketing Team</h3>
-      <p>Maintains this website and its content, and
-        looks for ways to improve general communication of
-        the project.
+      <p>
+        Maintains this website, responsible for social media outreach, collects metrics.
+        Mission: help grow the Nix user base.
       </p>
       <a class="button -primary" href="[%root%]community/teams/marketing.html">Read more</a>
 

--- a/community/teams/marketing.tt
+++ b/community/teams/marketing.tt
@@ -198,7 +198,7 @@
 
   <ul>
     <li>Set up continuous collection and presentation of metrics</li>
-    <li>Develop an adoption plan for the Nix platform</li>
+    <li>Develop communication strategy and adoption plan for the Nix platform</li>
     <li>Establish a communication workflow to support community teams with outreach
     <ul>
       <li>Support appearances in podcasts, interviews, conferences, ...</li>

--- a/community/teams/marketing.tt
+++ b/community/teams/marketing.tt
@@ -108,7 +108,7 @@
   <p>
     For example: There is only limited amount of space on the landing page.
     We will choose a narrow set of topics that best serve our purpose of increasing adoption most effectively.
-    The particular focus may change over time as we move through the adoption life cycle for our target audience.
+    The particular focus may change over time as we move through the <a href="https://en.wikipedia.org/wiki/Technology_adoption_life_cycle">adoption life cycle</a> for our target audience.
   </p>
 
   <h2>How to measure growth</h2>

--- a/community/teams/marketing.tt
+++ b/community/teams/marketing.tt
@@ -35,20 +35,188 @@
     </ul>
   </aside>
 
-  <h2>Responsibilities</h2>
+  <h1>Mission and strategy</h1>
+
+  <p>
+    We are the Nix marketing team, and our mission to help grow the Nix user base.
+  </p>
+
+  <h2>Why we want growth</h2>
+
+  <p>
+    Growth is instrumental to something. What is that?
+  </p>
+
+  <p>
+    We strive to advance the state of the art in software engineering.
+    That's why we're using and contributing to Nix.
+  </p>
+
+  <p>
+    Ultimately, we're interested in using and making software that is
+  </p>
+
   <ul>
-    <li>
-      Content and structure of the main website (nixos.org).
+    <li>more up-to-date</li>
+    <li>more reliable</li>
+    <li>easier to distribute</li>
+    <li>easier to integrate</li>
+    <li>easier to collaborate on.</li>
+  </ul>
+
+  <p>
+    We cannot achieve this alone.
+    As the Nix marketing team, we believe that talking about work done is as important as doing the work.
+    This is where we can help the Nix ecosystem to thrive.
+  </p>
+
+  <p>
+    We're convinced that the more people <em>know about</em> Nix, the more people will <em>use</em> Nix, and the more people will become <em>contributors and maintainers</em>.
+    We want to serve those people who are indispensible for maintaining and developing the Nix ecosystem, by promoting their work and facilitating communication with a wider audience.
+  </p>
+
+  <h2>How we want to grow</h2>
+
+  <p>
+    Our strategy is for the Nix ecosystem to become known for something unique we already excel at.
+    This is what we will emphasize in order to attract users.
+  </p>
+
+  <p>
+    This is not to set directions for development, but simply recognising and leveraging current strengths.
+  </p>
+
+  <h3>Target audience</h3>
+
+  <p>
+    Our target audience are software developers.
+  </p>
+
+  <p>
+    Nix tooling already fits developer use cases most closely, and it is developers who will derive the most value from using Nix in its current state.
+    Developers are also more likely to become contributors, and eventually maintainers.
+    Finally, among our users, software professionals have the greatest influence on organisations that can provide the resources necessary to keep developing and maintaining the Nix ecosystem.
+  </p>
+
+  <h3>Communication strategy</h3>
+
+  <p>
+    Nix can do many things.
+    If we start to talk about all of those things at once, the message gets lost.
+  </p>
+
+  <p>
+    For example: There is only limited amount of space on the landing page.
+    We will choose a narrow set of topics that best serve our purpose of increasing adoption most effectively.
+    The particular focus may change over time as we move through the adoption life cycle for our target audience.
+  </p>
+
+  <h2>How to measure growth</h2>
+
+  <p>
+    In order to know where we're going we need to know where we are.
+  </p>
+
+  <p>
+    Therefore, we will first collect metrics relevant to our mission, separated into phases in the user journey:
+  </p>
+
+  <h3>Discovery phase</h3>
+
+  <ul>
+    <li>Google Search trends</li>
+    <li>Social media impressions</li>
+    <li>Visits to the landing page</li>
+  </ul>
+
+  <h3>User phase</h3>
+
+  <ul>
+    <li>Number of members and messages on the community platforms (Discourse, Matrix, GitHub)</li>
+    <li>Binary cache usage</li>
+    <li>Number of queries on search.nixos.org</li>
+    <li>Website statistics on documentation</li>
+    <li>Community surveys</li>
+  </ul>
+
+  <h3>Contribution phase</h3>
+
+  <ul>
+    <li>Number of contributors and forks</li>
+    <li>Number of opened issues and pull requests</li>
+  </ul>
+
+  <h2>3-months plan (June through August 2023)</h2>
+
+  <p>
+    The current team consists of 5 people, each having ca. 2 hours per week available for working on marketing topics.
+    We estimate the required work to fulfill the following goals to ca. 115 hours over three months, given a total team capacity of ca. 120 hours in the same period.
+  </p>
+
+  <h3>Media outreach</h3>
+
+  <ul>
+    <li>More posts on social media
+    <ul>
+      <li>Currently involved: @idabzo @pxc @btjh @garbas @raboof</li>
+      <li>Estimated effort: 2h/week (24h total)</li>
+    </ul>
     </li>
-    <li>
-      Social media presence: Twitter, Youtube, ...
+    <li>Revive the newsletter
+    <ul>
+      <li>One post per month</li>
+      <li>Currently involved: @idabzo @garbas</li>
+      <li>Estimated effort: 2h/month (5h total)</li>
+    </ul>
+    </li>
+    <li>Continue &quot;What's new in Nix?&quot;
+    <ul>
+      <li>Goal: Release one video</li>
+      <li>Currently involved: @btjh @garbas @djacu @tomberek</li>
+      <li>Estimated effort: 20h</li>
+    </ul>
+    </li>
+    <li>(optional) Write a content policy
+    <ul>
+      <li>What to include, what not to</li>
+      <li>Which langauge to use</li>
+      <li>Define audience personae</li>
+      <li>Estimated effort: 10</li>
+    </ul>
     </li>
   </ul>
 
-  <h2>How to participate and help?</h2>
+  <h3>Community Survey 2023</h3>
+
+  <ul>
+    <li>Goal: publish in June</li>
+    <li>Currently involved: @garbas @kranzes @Arsleust</li>
+    <li>Estimated effort: 55h</li>
+  </ul>
+
+  <h2>1-year plan</h2>
+
+  <ul>
+    <li>Set up continuous collection and presentation of metrics</li>
+    <li>Develop an adoption plan for the Nix platform</li>
+    <li>Establish a communication workflow to support community teams with outreach
+    <ul>
+      <li>Support appearances in podcasts, interviews, conferences, ...</li>
+    </ul>
+    </li>
+    <li>Publish 12 newsletters</li>
+    <li>Publish 4 video updates</li>
+  </ul>
+
+  <h2>Get in touch</h2>
+
   <p>
-    Clearly the topics that the marketing team will discuss are very
-    bikesheddey. We would like to see the team being assembled from every corner
+    We are looking for additional members.
+    We are especially interested in people interested in frontend development, content creation for social media, and technical writing.
+  </p>
+
+  <p>
+    We would like to see the team being assembled from every corner
     of a Nix community. To join the team please write an email to
     <a href="mailto:webmaster@nixos.org">webmaster@nixos.org</a> trying to
     answer the following questions:
@@ -81,55 +249,6 @@
     is bootstrapped. Minutes of the meetings will be published with the potential
     agenda and the date of the next meeting.
   </p>
-
-  <h2>FAQ</h2>
-  <p>I tried to anticipate some questions/reactions:</p>
-  <ul>
-    <li>
-      <p>
-        <strong>
-          What’s with all the corporate lingo? We are an open source community
-          and not a company?
-        </strong>
-      </p>
-      <p>
-        It is the language I’m familiar with and I know few others are as well.
-        If there are things that bother you please contact any of us and propose
-        ways in which we can improve.
-      </p>
-    </li>
-    <li>
-      <p><strong>Why not use the RFC process?</strong></p>
-      <p>
-        The RFC process targets changes to the Nix ecosystem. Technical changes,
-        not social changes. Going through the RFC process would expose this
-        endeavor to unneeded bikeshedding.
-      </p>
-    </li>
-    <li>
-      <p>
-        <strong>
-          How will you avoid bikeshedding? How will you get anything done?
-        </strong>
-      </p>
-      <p>We will try to do our best. Patience is the key :)</p>
-    </li>
-    <li>
-      <p><strong>How will you handle controversial topics?</strong></p>
-      <p>
-        When a controversial topic comes to be discussed we will look at it from
-        all the sides and provide a summary. We will try to invite the
-        community (especially the concerned part of the community) to get
-        involved more and try to clarify in as much as clear way as possible.
-        Experience shows that most of the time problem is in communication and
-        this is what we will always try to do better.
-      </p>
-    </li>
-    <li>
-      <p><strong>I don’t like that the community is becoming professional, can we just hack?</strong></p>
-      <p>We always avoid success, but let’s try for once to plan it :)</p>
-    </li>
-  </ul>
 </section>
 
 [% END %]

--- a/community/teams/marketing.tt
+++ b/community/teams/marketing.tt
@@ -9,8 +9,7 @@
 </div>
 
 <section class="governance-description">
-  Marketing is everything non technical that helps adopt Nix and NixOS. And
-  that is also the purpose of this team.
+  We are the Nix marketing team, and our mission to help grow the Nix user base.
 </section>
 
 <section class="governance-team">
@@ -34,12 +33,6 @@
       <li><a href="mailto:webmaster@nixos.org">Email</a></li>
     </ul>
   </aside>
-
-  <h1>Mission and strategy</h1>
-
-  <p>
-    We are the Nix marketing team, and our mission to help grow the Nix user base.
-  </p>
 
   <h2>Why we want growth</h2>
 
@@ -149,7 +142,7 @@
   <h2>3-months plan (June through August 2023)</h2>
 
   <p>
-    The current team consists of 5 people, each having ca. 2 hours per week available for working on marketing topics.
+    The current team consists of 5 people with regular availability of ca. 2 hours per week for working on marketing topics.
     We estimate the required work to fulfill the following goals to ca. 115 hours over three months, given a total team capacity of ca. 120 hours in the same period.
   </p>
 


### PR DESCRIPTION
as developed by @garbas and some members of @nixos/marketing-team, me mainly acting as a scribe.
this concludes a series of discussions and clarifications.

the change also removes the FAQ that sounded needlessly apologetic, also
because all rationale should be provided in the mission statement.