### PR TITLE
blog: fix pubDate for NixOS 23.05 announcement

### DIFF
--- a/blog/announcements.xml
+++ b/blog/announcements.xml
@@ -2,7 +2,7 @@
 
 <news>
 <item>
-    <pubDate>Wed, 31 May</pubDate>
+    <pubDate>Wed, 31 May 2023 11:00:00 UTC</pubDate>
     <title id="nixos-23.05">
       NixOS 23.05 released
     </title>


### PR DESCRIPTION
According to the RSS 2.0 specification, the pubDate field needs to conform the Date and Time Specification of RFC 822[0]. Before this change, the pubDate was incomplete and my RSS feed reader parsed this as an invalid date.

```
> $ diff <(curl -s https://nixos.org/blog/announcements-rss.xml) <(curl -s http://localhost:8000/blog/announcements-rss.xml)
> 137c137
> <     </description><pubDate>Wed, 31 May</pubDate><guid isPermaLink="false">Wed, 31 May</guid></item><item><title>
> ---
> >     </description><pubDate>Wed, 31 May 2023 11:00:00 UTC</pubDate><guid isPermaLink="false">Wed, 31 May 2023 11:00:00 UTC</guid></item><item><title>
```

[0] https://validator.w3.org/feed/docs/rss2.html