### PR TITLE
fix Nürnberg meetup url

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -200,7 +200,7 @@
         <li><a href="https://www.meetup.com/Suisse-Romande-NixOS-User-Group/">Lausanne (Switzerland)</a></li>
         <li><a href="https://www.meetup.com/NixOS-London/">London (United Kingdom)</a></li>
         <li><a href="https://mobilizon.fr/@nix-mtp">Montpellier (France)</a></li>
-        <li><a href="https://matrix.to/#/#nixos-nuernberg:nerdberg.de">Nürnberg (Germany)</a></li>
+        <li><a href="https://matrix.to/#/#nixos-nuernberg:matrix.org">Nürnberg (Germany)</a></li>
         <li><a href="http://www.meetup.com/Munich-NixOS-Meetup/">Munich (Germany)</a></li>
         <li><a href="https://www.meetup.com/Oslo-NixOS-User-Group/">Oslo (Norway)</a></li>
         <li><a href="https://blog.shackspace.de/?p=5829">Stuttgart (Germany)</a></li>


### PR DESCRIPTION
Sorry for the trouble, I was able to join with the old url, but multiple people reported problems with the nerdberg.de domain so I changed it to matrix.org.