### PR TITLE
index: replace Reproducible with Declarative.

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -33,7 +33,7 @@
 <section class="home-hero">
   <div>
     <div class="blurb">
-      <h1>Reproducible builds <span>and deployments.</span></h1>
+      <h1>Declarative builds <span>and deployments.</span></h1>
       <p>
         Nix is a tool that takes a unique approach to package management and
         system configuration. Learn how to make reproducible, declarative and


### PR DESCRIPTION
NixOS does not support reproducible builds* so having this be the first word gives people the wrong impression considering how well-known this project is.

"Declarative" conveys the intent better.

* As defined by the Reproducible Builds projects