### PR TITLE
ci: `cron`: Update from hourly to daily

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,7 +1,7 @@
 name: "Hourly Build & Deploy to Netlify"
 on:
   schedule:
-  - cron: '0 * * * *'
+  - cron: '0 0 * * *'
 jobs:
   hourly-build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -9,15 +9,11 @@ jobs:
     steps:
     - name: Checking out the repository
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Installing Nix
       uses: cachix/install-nix-action@v22
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-        extra_nix_config: |
-          experimental-features = nix-command flakes
 
     - name: Setup Cachix
       uses: cachix/cachix-action@v12

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,59 +1,59 @@
 name: "Hourly Build & Deploy to Netlify"
 on:
   schedule:
-  - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 jobs:
   hourly-build-and-deploy:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
-    - name: Checking out the repository
-      uses: actions/checkout@v3
+      - name: Checking out the repository
+        uses: actions/checkout@v3
 
-    - name: Installing Nix
-      uses: cachix/install-nix-action@v22
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
+      - name: Installing Nix
+        uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
-    - name: Setup Cachix
-      uses: cachix/cachix-action@v12
-      with:
-        name: nixos-homepage
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v12
+        with:
+          name: nixos-homepage
+          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
 
-    - name: Update content
-      run: |
-        bash ./scripts/update.sh
+      - name: Update content
+        run: |
+          bash ./scripts/update.sh
 
-    - name: Building nixos.org
-      run: |
-        nix build
-        mkdir build
-        cp -RL ./result/* ./result/.well-known/ ./build/
+      - name: Building nixos.org
+        run: |
+          nix build
+          mkdir build
+          cp -RL ./result/* ./result/.well-known/ ./build/
 
-    - name: Deploy to Netlify
-      uses: nwtgck/actions-netlify@v2.0.0
-      env:
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-      with:
-        production-branch: 'master'
-        production-deploy: true
-        publish-dir: './build'
-        deploy-message: 'Deploy from GitHub Actions'
-        enable-pull-request-comment: true
-        enable-commit-comment: true
-        enable-commit-status: true
-        overwrites-pull-request-comment: false
-      if: github.repository == 'NixOS/nixos-homepage'
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v2.0.0
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        with:
+          production-branch: "master"
+          production-deploy: true
+          publish-dir: "./build"
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: true
+          enable-commit-status: true
+          overwrites-pull-request-comment: false
+        if: github.repository == 'NixOS/nixos-homepage'
 
-    - name: Commit updated files and push them to master branch
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: 'Hourly update [ci skip]'
-        branch: 'master'
-        file_pattern: flake.lock blog/announcements.xml
-        commit_user_name: NixOS webmaster
-        commit_user_email: webmaster@nixos.org
-        commit_author: GitHub Actions <webmaster@nixos.org>
-      if: github.repository == 'NixOS/nixos-homepage'
+      - name: Commit updated files and push them to master branch
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Hourly update [ci skip]"
+          branch: "master"
+          file_pattern: flake.lock blog/announcements.xml
+          commit_user_name: NixOS webmaster
+          commit_user_email: webmaster@nixos.org
+          commit_author: GitHub Actions <webmaster@nixos.org>
+        if: github.repository == 'NixOS/nixos-homepage'


### PR DESCRIPTION
Hi,

This opinionated PR proposes the following changes:

1. Changes the `cron` workflow from running `hourly` to `daily`
2. Remove obsolete options that are enabled by default on some actions
3. Reformat the file using `prettier`: `nix run nixpkgs#nodePackages.prettier -- --write .github/workflows/cron.yml`