### PR TITLE
Nixpkgs architecture team: Indicate me as the leader

### DIFF
--- a/community/teams/nixpkgs-architecture.tt
+++ b/community/teams/nixpkgs-architecture.tt
@@ -15,12 +15,15 @@
 <section class="governance-team">
 
   <aside>
-    <h2>Members</h2>
-
+    <h2>Leader</h2>
     <ul>
       <li>
         Silvan Mosberger (<a href="https://matrix.to/#/@infinisil:matrix.org">@infinisil:matrix.org</a>, <a href="https://github.com/infinisil/">@infinisil</a>, <a href="https://tweag.io">Tweag</a>)
       </li>
+    </ul>
+
+    <h2>Members</h2>
+    <ul>
       <li>
         Thomas Bereknyei (<a href="https://matrix.to/#/@tomberek:matrix.org">@tomberek:matrix.org</a>, <a href="https://github.com/tomberek/">@tomberek</a>, <a href="https://floxdev.com/">Flox</a>)
       </li>


### PR DESCRIPTION
Following @zimbatm's initiative in #1100.
This also relates to a corresponding PR to the Nixpkgs Architecture team page to describe the leaders responsibilities: https://github.com/nixpkgs-architecture/.github/pull/7