### PR TITLE
Remove Black River Software [no longer operating] from service providers

### DIFF
--- a/community/commercial-support.tt
+++ b/community/commercial-support.tt
@@ -32,18 +32,6 @@ integration and administration.
     </li>
 
     <li>
-      <a href="http://blackriversoft.com/">
-        <div>
-          <img alt="Black River Software" src="/community/commercial-support-logos/black-river-software.png" />
-        </div>
-        <h2>Black River Software</h2>
-        <ul><li>Ohio, USA</li></ul>
-        Black River Software offers custom software development, software architecture
-consulting, and build and deployment engineering services.
-      </a>
-    </li>
-
-    <li>
       <a href="https://determinate.systems/">
         <div>
           <img alt="Determinate Systems" src="/community/commercial-support-logos/determinate-systems.svg" />


### PR DESCRIPTION
I'm no longer operating Black River Software, so it should be removed from the list of Nix/NixOS service providers.