### PR TITLE
commercial-support: fix url for serokell

### DIFF
--- a/community/commercial-support.tt
+++ b/community/commercial-support.tt
@@ -105,7 +105,7 @@ methodology and workflow
     </li>
 
     <li>
-      <a href="https://nixos.mayflower.consulting">
+      <a href="https://serokell.io/">
         <div>
           <img alt="Serokell" src="/community/commercial-support-logos/serokell.png" />
         </div>


### PR DESCRIPTION
Somehow this got mixed up with mayflower. I am not re-adding mayflower since I have sources that most (all?) NixOS-related people will have left the company by next year.