### PR TITLE
Fix nix.dev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,15 +100,14 @@
     "nix-dev": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs",
-        "poetry2nix": "poetry2nix"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1695239492,
-        "narHash": "sha256-0UMgqbnh4d72kUHjzTayZuwQtS80WdeOfbk2L/oF9K0=",
+        "lastModified": 1698751113,
+        "narHash": "sha256-7uFp9cjnpyuiJUtAbJAjWAqQQ/NsQwSj3F64drdq3VQ=",
         "owner": "NixOS",
         "repo": "nix.dev",
-        "rev": "62db5ba51d581f4f72b4ce438f74e0e47e7a79cf",
+        "rev": "12846fc6c2a818bc5991a386b34887bb790f00d2",
         "type": "github"
       },
       "original": {
@@ -261,31 +260,6 @@
         "owner": "NixOS",
         "ref": "nixos-23.05-small",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "poetry2nix": {
-      "inputs": {
-        "flake-utils": [
-          "nix-dev",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nix-dev",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1685418143,
-        "narHash": "sha256-q2ORekI8au0pGMtOLQI8WMCJBxjzWgYRHpiEOVSBq3w=",
-        "owner": "nix-community",
-        "repo": "poetry2nix",
-        "rev": "f11cc14e28078c701072f2d1fb34a6495c9376b1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "poetry2nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,7 @@ rec {
                 "NIXOS_AMIS=${nixosAmis}"
                 "NIX_PILLS_MANUAL_IN=${nixPills.html-split}/share/doc/nix-pills"
                 "NIX_PILLS_MANUAL_EPUB=${nixPills.epub}/share/doc/nix-pills/nix-pills.epub"
-                "NIX_DEV_MANUAL_IN=${nix-dev.defaultPackage.${system}}"
+                "NIX_DEV_MANUAL_IN=${nix-dev.packages.${system}.default}"
 
                 "-j 1"
               ];
@@ -174,7 +174,7 @@ rec {
               export NIXOS_AMIS="${nixosAmis}"
               export NIX_PILLS_MANUAL_IN="${nixPills.html-split}/share/doc/nix-pills"
               export NIX_PILLS_MANUAL_EPUB="${nixPills.epub}/share/doc/nix-pills/nix-pills.epub"
-              export NIX_DEV_MANUAL_IN="${nix-dev.defaultPackage.${system}}"
+              export NIX_DEV_MANUAL_IN="${nix-dev.packages.${system}.default}"
 
               rm -f site-styles/common-styles
               ln -s ${nixos-common-styles.packages."${system}".commonStyles} site-styles/common-styles

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,6 +4,7 @@ set -e
 
 echo "Updating flake inputs..."
 nix flake lock \
+  --extra-experimental-features 'nix-command flakes' \
   --update-input released-nixpkgs-unstable \
   --update-input released-nixpkgs-stable \
   --update-input released-nix-unstable \
@@ -12,4 +13,6 @@ nix flake lock \
   --update-input nix-dev
 
 echo "Updating blog..."
-nix develop --command update-blog --output-dir blog/
+nix develop \
+  --extra-experimental-features 'nix-command flakes' \
+  --command update-blog --output-dir blog/


### PR DESCRIPTION
The nix.dev flake changed the output schema in
https://github.com/NixOS/nix.dev/commit/957bda73d48d40132a36159eb7392d3a03e92ebd

This failed the last attempted automated CI update:
https://github.com/NixOS/nixos-homepage/actions/runs/6700205463/job/18205745665