### PR TITLE
Remove grahamc from the security team

### DIFF
--- a/community/teams/security.tt
+++ b/community/teams/security.tt
@@ -40,13 +40,6 @@
     <ul>
       <li>
         <p>
-          <a href="https://discourse.nixos.org/u/grahamc">Graham Christensen</a>,
-          <a href="mailto:graham@determinate.systems">graham@determinate.systems</a>
-          (gchristensen)
-        </p>
-      </li>
-      <li>
-        <p>
           <a href="https://discourse.nixos.org/u/hexa">Martin Weinelt</a>,
           <a href="mailto:hexa@darmstadt.ccc.de">hexa@darmstadt.ccc.de</a>
           (hexa)


### PR DESCRIPTION
After a long tenure on many teams, and founding the security team -- it is beyond time for me to step down and leave it in the very capable hands of the other members.

I'm around if y'all need me :), and thanks for taking it to greater heights!