### PR TITLE
Update NixCon team

### DIFF
--- a/community/teams/nixcon.tt
+++ b/community/teams/nixcon.tt
@@ -14,16 +14,13 @@
 </section>
 
 <section class="governance-team">
-
   <aside>
     <h2>Members</h2>
+    The NixCon team is transitioning.
     <ul>
-      <li><a href="https://discourse.nixos.org/u/flokli">Florian Klink</a> (flokli)</li>
-      <li><a href="https://discourse.nixos.org/u/addict3d">Nick Bathum</a> (addict3d)</li>
-      <li><a href="https://discourse.nixos.org/u/zimbatm">zimbatm</a> (zimbatm)</li>
+      <li><a href="https://discourse.nixos.org/t/governance-through-project-leads-in-nixcon-2024/33981">Governance through “project leads” in NixCon 2024</a></li>
     </ul>
   </aside>
-
 </section>
 
 [% END %]


### PR DESCRIPTION
The NixCon team is transitioning.

For more information, please see the discourse post: [Governance through “project leads” in NixCon 2024](https://discourse.nixos.org/t/governance-through-project-leads-in-nixcon-2024/33981)