### PR TITLE
Allow triggering manual updates

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,6 +2,8 @@ name: "Hourly Build & Deploy to Netlify"
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+
 jobs:
   hourly-build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,4 +1,4 @@
-name: "Hourly Build & Deploy to Netlify"
+name: "Daily Build & Deploy to Netlify"
 on:
   schedule:
     - cron: "0 0 * * *"
@@ -52,7 +52,7 @@ jobs:
       - name: Commit updated files and push them to master branch
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Hourly update [ci skip]"
+          commit_message: "Daily update [ci skip]"
           branch: "master"
           file_pattern: flake.lock blog/announcements.xml
           commit_user_name: NixOS webmaster


### PR DESCRIPTION
This enables the [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) trigger, allowing the daily updates to be trigger manually from https://github.com/NixOS/nixos-homepage/actions/workflows/cron.yml

I want this so I can link people to new sections in the Nixpkgs/NixOS manual without having to wait for the daily update.

Also, so I can force an update already now, since updates were broken [for 5 days](https://github.com/NixOS/nixos-homepage/pull/1163#issuecomment-1827677297).