### PR TITLE
Update `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,11 +119,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1701102799,
-        "narHash": "sha256-jpMrRE1f4gf2+cgmGKPaO4oWszXLqfRQ21tCP4dWVwA=",
+        "lastModified": 1701179026,
+        "narHash": "sha256-mPghFKfIoZov1hJ9a9ZZQUse7YBdUgSMT6t9nQvfzNo=",
         "owner": "NixOS",
         "repo": "nixos-common-styles",
-        "rev": "d2a7e90d79ba4287c39b24788bba653bed13e93c",
+        "rev": "2f9e5b8c1323ab35ae3b6e7c03a0ee6db6e34110",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Since https://github.com/NixOS/nixos-common-styles/pull/29 has been merged... it's time to update this project, hopefully this will fix the black mastodon icon.