### PR TITLE
@phaer leaves the Nixpkgs Architecture Team

### DIFF
--- a/community/teams/nixpkgs-architecture.tt
+++ b/community/teams/nixpkgs-architecture.tt
@@ -37,9 +37,6 @@
         Alex Ameen (<a href="https://matrix.to/#/@growpotkin1:matrix.org">@growpotkin1:matrix.org</a>, <a href="https://github.com/aakropotkin/">@aakropotkin</a>, <a href="https://tulip.co/platform/analytics/">Tulip Interfaces</a>)
       </li>
       <li>
-        Paul Haerle (<a href="https://matrix.to/#/@phaer:matrix.org">@phaer:matrix.org</a>, <a href="https://github.com/phaer/">@phaer</a>)
-      </li>
-      <li>
         David Hauer (<a href="https://matrix.to/#/@hsngrmpf:matrix.org">@hsngrmpf:matrix.org</a>, <a href="https://github.com/DavHau/">@DavHau</a>)
       </li>
     </ul>


### PR DESCRIPTION
Voluntarily on their own in todays meeting: https://github.com/nixpkgs-architecture/team-log/commit/2578a77fff8c6519c24acc80f2bc5d19293af50d, https://github.com/nixpkgs-architecture/meetings/blob/master/2023-11-28.md