### PR TITLE
index: prevent announcement link from opening twice

### DIFF
--- a/index.tt
+++ b/index.tt
@@ -25,7 +25,7 @@
       NixOS 23.11 <span class="-detailed">released.</span>
     </div>
     <div class="action">
-      <a target="_blank" href="[% root %]blog/announcements.html#nixos-23.11">Announcement</a>
+      <a href="[% root %]blog/announcements.html#nixos-23.11">Announcement</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixes #1175 

Removes the `_blank` target which doesn't work properly with the `clickable-whole` class since it has an attached `click` jquery handler.