### PR TITLE
Astro/Fix Button component for size lg-full

### DIFF
--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -23,7 +23,7 @@ const sizeMap = {
     "sm": "px-10 py-2.5 rounded-3xl",
     "sm-mobfull": "px-8 py-2.5 rounded-3xl md:w-auto w-full text-center",
     "lg": "px-14 py-4 rounded-2xl",
-    "lg-full": "text-center py-4 w-full rounded-2xl"
+    "lg-full": "text-center py-4 block rounded-2xl"
 }
 
 const {


### PR DESCRIPTION
Fixes the lg-full size in the Button component as mentioned here: https://github.com/NixOS/nixos-homepage/pull/1164#issuecomment-1845426366