### PR TITLE
Astro/Fix Tag Component

### DIFF
--- a/src/components/ui/Tag.astro
+++ b/src/components/ui/Tag.astro
@@ -22,6 +22,13 @@ const {
 const localClassList = `${colorMap[color]} w-fit rounded-lg font-bold !text-white !no-underline text-sm px-[0.5rem] py-[0.25rem]`;
 ---
 
-<a href={href} class:list={[localClassList, classList]}>
-  <slot/>
-</a>
+{href
+  ?
+    <a href={href} class:list={[localClassList, classList]}>
+      <slot/>
+    </a>
+  :
+    <span href={href} class:list={[localClassList, classList]}>
+      <slot/>
+    </span>
+}

--- a/src/components/ui/Tag.astro
+++ b/src/components/ui/Tag.astro
@@ -17,7 +17,7 @@ const {
   classList = [],
 } = Astro.props;
 
-const localClassList = `${colorMap[color]} rounded-lg font-bold text-white text-sm px-[0.5rem] py-[0.25rem]`;
+const localClassList = `${colorMap[color]} w-fit rounded-lg font-bold text-white text-sm px-[0.5rem] py-[0.25rem]`;
 ---
 
 <span class:list={[localClassList, classList]}>

--- a/src/components/ui/Tag.astro
+++ b/src/components/ui/Tag.astro
@@ -1,7 +1,7 @@
 ---
 
 interface Props {
-  color?: "orange" | "darkgreen" | "lightblue" | "semidarkblue";
+  color?: "orange" | "darkgreen" | "lightblue" | "darkblue";
   classList?: string[];
   href?: string | null;
 }
@@ -9,12 +9,12 @@ interface Props {
 const colorMap = {
   "orange": "bg-nixorange",
   "lightblue": "bg-nixlightblue",
-  "semidarkblue": "bg-nixsemidarkblue",
+  "darkblue": "bg-nixdarkblue",
   "darkgreen": "bg-nixdarkgreen"
 }
 
 const {
-  color = "semidarkblue",
+  color = "darkblue",
   classList = [],
   href = null,
 } = Astro.props;

--- a/src/components/ui/Tag.astro
+++ b/src/components/ui/Tag.astro
@@ -3,6 +3,7 @@
 interface Props {
   color?: "orange" | "darkgreen" | "lightblue" | "semidarkblue";
   classList?: string[];
+  href?: string | null;
 }
 
 const colorMap = {
@@ -15,11 +16,12 @@ const colorMap = {
 const {
   color = "semidarkblue",
   classList = [],
+  href = null,
 } = Astro.props;
 
-const localClassList = `${colorMap[color]} w-fit rounded-lg font-bold text-white text-sm px-[0.5rem] py-[0.25rem]`;
+const localClassList = `${colorMap[color]} w-fit rounded-lg font-bold !text-white !no-underline text-sm px-[0.5rem] py-[0.25rem]`;
 ---
 
-<span class:list={[localClassList, classList]}>
+<a href={href} class:list={[localClassList, classList]}>
   <slot/>
-</span>
+</a>


### PR DESCRIPTION
Fix Tag component:
- so hrefs work.
- uses the correct 'nix blue' value.
- so the background fits the contents. Without the `w-fit` class it looks like the bottom tag instead of the top.

![Screenshot 2023-12-08 at 19-46-50 Explore](https://github.com/NixOS/nixos-homepage/assets/7043297/3a608302-d025-4625-b786-43cec87c45e4)
