### PR TITLE
fix(style): eliminate some scrollburglars

### DIFF
--- a/site-styles/pages/blog.less
+++ b/site-styles/pages/blog.less
@@ -105,6 +105,10 @@
   #screen-sm-min({
     padding: 0 2*@gutter;
   });
+
+  code {
+    display: inline;
+  }
 }
 
 .blog-categories {

--- a/site-styles/pages/main.less
+++ b/site-styles/pages/main.less
@@ -1,3 +1,7 @@
+main {
+  overflow-wrap: break-word;
+}
+
 .home-hero {
   #flair.outlined-bg-dark();
 

--- a/site-styles/pages/manual.less
+++ b/site-styles/pages/manual.less
@@ -59,6 +59,7 @@ div.docbook {
   }
 
   code {
+    display: inline;
     padding: 0;
     border: 0;
     background-color: inherit;
@@ -110,6 +111,7 @@ div.docbook {
     th, td {
       padding: @gutter/2;
     }
+    overflow-x: auto;
   }
 
   // "Re-order" the styles for the headers


### PR DESCRIPTION
A scrollburglar is an issue mainly affecting mobile devices where scrolling down (e.g. by dragging up with your finger) often unintentionally results in a horizontal scroll due to the page content overflowing the viewport width. (I believe this was coined by [Josh W. Comeau](https://www.joshwcomeau.com/).)

![Scrollburglar Example](https://github.com/NixOS/nixos-homepage/assets/38332081/009f7434-c838-401a-8ffc-afa10bed6678)

The scrollburglar instances I noticed were on the [blog page](https://nixos.org/blog/) and [some](https://nixos.org/manual/nixos/stable/) of the [manual pages](https://nixos.org/manual/nixpkgs/stable/). You can open the mobile view in Firefox with the shortcut `Ctrl+Shift-M`. (It's also possible in other browsers.)

I tried to limit the scope of the `display: inline` applied to `code` elements in case the original `display: inline-block` was important in some contexts.

### Relevant links

- [`overflow-wrap: break-word`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#break-word)
- [`overflow: auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#auto)