### PR TITLE
workflows/cron: Pin Nix to 2.19.2, fix updates

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -16,6 +16,9 @@ jobs:
         uses: cachix/install-nix-action@v24
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          # Pin Nix so that CI doesn't randomly break again
+          # And we don't want 2.19.1 because that doesn't have backwards compatible support for --update-input
+          install_url: https://releases.nixos.org/nix/nix-2.19.2/install
 
       - name: Setup Cachix
         uses: cachix/cachix-action@v13


### PR DESCRIPTION
The current default for cachix/install-nix-action@v24 is 2.19.1, which annoyingly completely removed support for `--update-input`, which the homepages udpate script was relying upon. Only 2.19.2 reinstated support for that flag with a deprecation notice.

Also by pinning we prevent such problems in the future. Notably in this case this caused the docs on nixos.org to not update **for 2 months**.

I tested the script locally. After merging I'll manually trigger the action