### PR TITLE
Update the moderation team email address

### DIFF
--- a/community/teams/moderation.tt
+++ b/community/teams/moderation.tt
@@ -34,7 +34,7 @@ href="https://github.com/NixOS/rfcs/blob/master/rfcs/0102-moderation-team.md">RF
 
   <p>
   <ul>
-    <li>E-mail: <a href="mailto:community@nixos.org">community@nixos.org</a></li>
+    <li>E-mail: <a href="mailto:moderation@nixos.org">moderation@nixos.org</a></li>
     <li>Matrix room: <a href="https://matrix.to/#/#moderation:nixos.org">#moderation:nixos.org</a></li>
     <li>On Discourse: <a href="https://discourse.nixos.org/g/moderators">moderators group</a></li>
     <li>On GitHub, ping <a href="https://nixos.org/community/teams/moderation">@NixOS/moderation</a></li>


### PR DESCRIPTION
The previous address is still intact, but since it led to confusions we went to clear this up.