### PR TITLE
Revert "Add ap/tokodon tag link to community"

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -58,7 +58,7 @@
           <a alt="Twitter" href="https://twitter.com/hashtag/NixOS">Twitter</a>
         </li>
         <li class="social-icon -mastodon">
-          <a alt="Mastodon" href="https://mastodon.social/tags/nixos">Mastodon</a> (<a alt="Tokodon" href="web+ap://tag:nixos@mastodon.social/">Tokodon</a>)
+          <a alt="Mastodon" href="https://mastodon.social/tags/nixos">Mastodon</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Reverts NixOS/nixos-homepage#1182

turns out we actually need to redesign this thing, sorry.