### PR TITLE
Update link to latest Hydra manual job

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -481,7 +481,7 @@
 
 [[redirects]]
   from  = "/hydra/manual"
-  to = "https://hydra.nixos.org/job/hydra/master/manual/latest/download-by-type/doc/manual"
+  to = "https://hydra.nixos.org/job/hydra/master/manual.x86_64-linux/latest/download-by-type/doc/manual"
   status = 302
   force = true
 


### PR DESCRIPTION
The Hydra manual in the current location has not been updated since 2022, as the jobset was split into architecture-specific variants.