### PR TITLE
Update events

### DIFF
--- a/community/index.tt
+++ b/community/index.tt
@@ -202,7 +202,6 @@
         <li><a href="https://www.meetup.com/New-York-Nix-Users-Group/">New York (New York)</a></li>
         <li><a href="https://www.meetup.com/Nova-Nix-NixOS-NixOps-Meetup/">Reston (Virginia)</a></li>
         <li><a href="http://www.meetup.com/Bay-Area-Nix-NixOS-User-Group/">San Francisco (California)</a></li>
-        <li><a href="https://www.meetup.com/Seattle-Nix-NixOS-and-Guix-GuixSD-Users/">Seattle (Washington)</a></li>
       </ul>
     </li>
     <li>
@@ -211,8 +210,7 @@
         <li><a href="http://www.meetup.com/Amsterdam-Nix-Meetup/">Amsterdam (Netherlands)</a></li>
         <li><a href="http://www.meetup.com/Berlin-NixOS-Meetup/">Berlin (Germany)</a></li>
         <li><a href="https://www.meetup.com/Greater-Copenhagen-NixOS-User-Group">Copenhagen (Denmark)</a></li>
-        <li><a href="https://www.meetup.com/Suisse-Romande-NixOS-User-Group/">Lausanne (Switzerland)</a></li>
-        <li><a href="https://www.meetup.com/NixOS-London/">London (United Kingdom)</a></li>
+        <li><a href="https://www.eventbrite.co.uk/e/london-nix-user-group-tickets-729796249227">London (United Kingdom)</a></li>
         <li><a href="https://mobilizon.fr/@nix-mtp">Montpellier (France)</a></li>
         <li><a href="https://matrix.to/#/#nixos-nuernberg:matrix.org">Nürnberg (Germany)</a></li>
         <li><a href="http://www.meetup.com/Munich-NixOS-Meetup/">Munich (Germany)</a></li>


### PR DESCRIPTION
London group seems to have relocated to Eventbrite.

Removing Lausanne and Seattle as they seem to have closed.