### PR TITLE
Fix some team usernames and make it clear they're for discourse

### DIFF
--- a/src/content/teams/01_foundation-board.mdx
+++ b/src/content/teams/01_foundation-board.mdx
@@ -3,22 +3,22 @@ name: Foundation board
 description: Responsible for providing operational and organizational support to the NixOS project and community.
 members:
 - name: Eelco Dolstra
-  username: edolstra
+  discourse: edolstra
   title: Chair
 - name: Ron Efroni
-  username: ron
+  discourse: ron
   title: Treasurer
 - name: Théophane Hufschmitt
-  username: thufschmitt
+  discourse: thufschmitt
   title: Secretary
 - name: Domen Kozar
-  username: domenkozar
+  discourse: domenkozar
   title: Member
 - name: Jonas Chevalier
-  username: zimbatm
+  discourse: zimbatm
   title: Member
 - name: Ryan Lahfa
-  username: RaitoBezarius
+  discourse: RaitoBezarius
   title: Observer
 contact:
 - name: Discourse

--- a/src/content/teams/02_rfc-steering-committee.mdx
+++ b/src/content/teams/02_rfc-steering-committee.mdx
@@ -3,17 +3,17 @@ name: RFC Steering Committee
 description: Responsible for forming an RFC Shepherd team from the available nominations on each RFC, which is then responsible for accepting or rejecting a specific RFC.
 members:
 - name: Kevin Cox
-  username: kevincox
+  discourse: kevincox
 - name: Linus Heckemann
-  username: lheckemann
+  discourse: lheckemann
 - name: Silvan Mosberger
-  username: infinisil
+  discourse: infinisil
 - name: Priyanshu Tripathi
-  username: GetPsyched
+  discourse: GetPsyched
 - name: Jonathan Ringer
-  username: jonringer
+  discourse: jonringer
 - name: Matthias Meschede
-  username: mat
+  discourse: mat
 contact:
 - name: No contact provided
 ---

--- a/src/content/teams/03_security.mdx
+++ b/src/content/teams/03_security.mdx
@@ -3,16 +3,16 @@ name: Security Team
 description: Security is a priority for the NixOS community. In addition to community-sourced developments, NixOS has a dedicated team, to look into privately reported security issues.
 members:
 - name: Martin Weinelt
-  username: hexa
+  discourse: hexa
   title:
 - name: Linus Heckemann
-  username: lheckemann
+  discourse: lheckemann
   title:
 - name: Robert Scott
-  username: ris
+  discourse: ris
   title:
 - name: Thomas Gerbet
-  username: tgerbet
+  discourse: tgerbet
   title:
 contact:
 - name: Matrix

--- a/src/content/teams/04_infrastructure.mdx
+++ b/src/content/teams/04_infrastructure.mdx
@@ -3,15 +3,15 @@ name: Infrastructure Team
 description: Provides infrastructure for the Nix and NixOS community.
 members:
 - name: Amine Chikhaoui
-  username: aminechikhaoui
+  discourse: aminechikhaoui
 - name: Eelco Dolstra
-  username: edolstra
+  discourse: edolstra
 - name: Graham Christensen
-  username: grahamc
+  discourse: grahamc
 - name: Jonas Chevalier
-  username: zimbatm
+  discourse: zimbatm
 - name: Vladimír Čunát
-  username: vcunat
+  discourse: vcunat
 contact:
 - name: Discourse
   href: https://discourse.nixos.org/c/dev/infrastructure-team/31

--- a/src/content/teams/05_nixos-release.mdx
+++ b/src/content/teams/05_nixos-release.mdx
@@ -3,10 +3,10 @@ name: NixOS Release Team
 description: Manages the twice-yearly releases of NixOS. It is responsible the entire release process from setting the roadmap to uploading the artifacts.
 members:
 - name: figsoda
-  username: figsoda
+  discourse: figsoda
   title:
 - name: Ryan Lahfa
-  username: RaitoBezarius
+  discourse: RaitoBezarius
   title:
 contact:
 - name: Discourse

--- a/src/content/teams/07_marketing.mdx
+++ b/src/content/teams/07_marketing.mdx
@@ -3,22 +3,22 @@ name: Marketing Team
 description: Maintains this website, responsible for social media outreach, collects metrics. Help grow the Nix user base.
 members:
 - name: Rok Garbas
-  username: garbas
+  discourse: garbas
   title: Leader
 - name: Thomas Bereknyei
-  username: tomberek
+  discourse: tomberek
   title:
 - name: Ida Bzo
-  username: idabzo
+  discourse: idabzo
   title:
 - name: Guillaume Desforges
-  username: arsleust
+  discourse: arsleust
   title:
 - name: Dan Baker
-  username: djacu
+  discourse: djacu
   title:
 - name: Thilo Billerbeck
-  username: avocadoom
+  discourse: avocadoom
   title:
 contact:
 - name: Discourse

--- a/src/content/teams/08_moderation.mdx
+++ b/src/content/teams/08_moderation.mdx
@@ -15,7 +15,7 @@ members:
   discourse: ryantm
   title:
 - name: piegames
-  discourse: piegamesde
+  discourse: piegames
   title:
 contact:
 - name: E-mail

--- a/src/content/teams/08_moderation.mdx
+++ b/src/content/teams/08_moderation.mdx
@@ -3,19 +3,19 @@ name: Moderation Team
 description: Moderates participation on official community platforms.
 members:
 - name: Graham Christensen
-  username: grahamc
+  discourse: grahamc
   title:
 - name: Jörg Thalheim
-  username: mic92
+  discourse: mic92
   title:
 - name: Martin Weinelt
-  username: hexa
+  discourse: hexa
   title:
 - name: Ryan Mulligan
-  username: ryantm
+  discourse: ryantm
   title:
 - name: piegames
-  username: piegamesde
+  discourse: piegamesde
   title:
 contact:
 - name: E-mail

--- a/src/content/teams/09_cuda.mdx
+++ b/src/content/teams/09_cuda.mdx
@@ -3,13 +3,13 @@ name: CUDA Team
 description: Making Nix and NixOS the first choice for users of CUDA-accelerated software.
 members:
 - name: Samuel A
-  username: samuela
+  discourse: samuela
   title: Team creator
 - name: Serge K
-  username: sergek
+  discourse: sergek
   title:
 - name: Connor Baker
-  username: connorbaker
+  discourse: connorbaker
   title: Sponsored by Tweag
 contact:
 - name: Discourse

--- a/src/content/teams/10_nix.mdx
+++ b/src/content/teams/10_nix.mdx
@@ -3,22 +3,22 @@ name: Nix Team
 description: Maintains and releases the Nix package manager.
 members:
 - name: Eelco Dolstra
-  username: edolstra
+  discourse: edolstra
   title: Team lead
 - name: Théophane Hufschmitt
-  username: regnat
+  discourse: regnat
   title:
 - name: Valentin Gagarin
-  username: fricklerhandwerk
+  discourse: fricklerhandwerk
   title:
 - name: Thomas Bereknyei
-  username: tomberek
+  discourse: tomberek
   title:
 - name: Robert Hensing
-  username: roberth
+  discourse: roberth
   title:
 - name: John Ericson
-  username: Ericson2314
+  discourse: Ericson2314
   title:
 contact:
 - name: Discourse

--- a/src/content/teams/10_nix.mdx
+++ b/src/content/teams/10_nix.mdx
@@ -6,7 +6,7 @@ members:
   discourse: edolstra
   title: Team lead
 - name: Théophane Hufschmitt
-  discourse: regnat
+  discourse: thufschmitt
   title:
 - name: Valentin Gagarin
   discourse: fricklerhandwerk

--- a/src/content/teams/11_documentation.mdx
+++ b/src/content/teams/11_documentation.mdx
@@ -21,7 +21,7 @@ members:
   discourse: wamirez
   title:
 - name: yukiisbored
-  discourse: yukiisbored
+  discourse: yuki_is_bored
   title:
 - name: proofconstruction
   discourse: proofconstruction

--- a/src/content/teams/11_documentation.mdx
+++ b/src/content/teams/11_documentation.mdx
@@ -3,34 +3,34 @@ name: Documentation Team
 description: Works on improving learning experience and documentation.
 members:
 - name: Valentin Gagarin
-  username: fricklerhandwerk
+  discourse: fricklerhandwerk
   title: Nix documentarian, Sponsored by Antithesis via Tweag
 - name: Silvan Mosberger
-  username: infinisil
+  discourse: infinisil
   title: Nixpkgs maintainer, Sponsored by Tweag
 - name: Olaf
-  username: olaf
+  discourse: olaf
   title:
 - name: henrik-ch
-  username: henrik-ch
+  discourse: henrik-ch
   title:
 - name: asymmetric
-  username: asymmetric
+  discourse: asymmetric
   title:
 - name: wamirez
-  username: wamirez
+  discourse: wamirez
   title:
 - name: yukiisbored
-  username: yukiisbored
+  discourse: yukiisbored
   title:
 - name: proofconstruction
-  username: proofconstruction
+  discourse: proofconstruction
   title:
 - name: alejandrosame
-  username: alejandrosame
+  discourse: alejandrosame
   title:
 - name: Bernardo Stein
-  username: danielsidhion
+  discourse: danielsidhion
   title:
 contact:
 - name: Discourse

--- a/src/pages/community/teams/[...slug].astro
+++ b/src/pages/community/teams/[...slug].astro
@@ -30,9 +30,9 @@ const { Content } = await entry.render();
           entry.data.members.map((member) => (
             <li class="mb-1 last:mb-0">
               {member.name}
-              {member.username && (
+              {member.discourse && (
                 <>
-                (<a href={"https://discourse.nixos.org/u/" + member.username}>@{member.username}</a>)
+                (<a href={"https://discourse.nixos.org/u/" + member.discourse}>@{member.discourse}</a>)
                 </>
               )}
               {member.title && (


### PR DESCRIPTION
In another PR I'll also add a team with GitHub usernames instead.