### PR TITLE
Download: fix tab navigation by removing unnecessary span

### DIFF
--- a/src/components/pages/download/DownloadAccordion.astro
+++ b/src/components/pages/download/DownloadAccordion.astro
@@ -40,7 +40,7 @@ let downloadOptions = (await getCollection("download")).filter(
                   "my-4",
                 ]}
               >
-                <span>{option.data.title}</span>
+                {option.data.title}
               </button>
             </h3>
             <div


### PR DESCRIPTION
Removing the download tabs  `<span>` attribute since it causes problems and is unneeded anyway