### PR TITLE
teams: use matrix.to instead of app.element.io for links

### DIFF
--- a/src/content/teams/01_foundation-board.mdx
+++ b/src/content/teams/01_foundation-board.mdx
@@ -24,7 +24,7 @@ contact:
 - name: Discourse
   href: https://discourse.nixos.org/c/dev/nixos-foundation/47
 - name: Matrix
-  href: https://app.element.io/#/room/#foundation:nixos.org
+  href: https://matrix.to/#/#foundation:nixos.org
 - name: GitHub project board
   href: https://github.com/orgs/NixOS/projects/28
 ---
@@ -55,7 +55,7 @@ import Button from "../../components/ui/Button.astro";
 
 <div class="flex flex-wrap gap-4">
   <Button color="semidarkblue" size="sm" href="https://discourse.nixos.org/c/dev/nixos-foundation/47">Discourse</Button>
-  <Button color="semidarkblue" size="sm" href="https://app.element.io/#/room/#foundation:nixos.org">Matrix</Button>
+  <Button color="semidarkblue" size="sm" href="https://matrix.to/#/#foundation:nixos.org">Matrix</Button>
   <Button color="semidarkblue" size="sm" href="https://github.com/orgs/NixOS/projects/28">GitHub Project board</Button>
   <Button color="semidarkblue" size="sm" href="https://github.com/orgs/NixOS/teams/foundation">GitHub Team page</Button>
 </div>

--- a/src/content/teams/09_cuda.mdx
+++ b/src/content/teams/09_cuda.mdx
@@ -15,7 +15,7 @@ contact:
 - name: Discourse
   href: https://discourse.nixos.org/t/announcing-the-nixos-cuda-maintainers-team-and-a-call-for-maintainers/18074
 - name: Matrix
-  href: https://app.element.io/#/room/#cuda:nixos.org
+  href: https://matrix.to/#/#cuda:nixos.org
 - name: GitHub project board
   href: https://github.com/orgs/NixOS/projects/27
 ---
@@ -73,7 +73,7 @@ import Button from "../../components/ui/Button.astro";
     href="https://discourse.nixos.org/t/announcing-the-nixos-cuda-maintainers-team-and-a-call-for-maintainers/18074"
     color="semidarkblue" size="sm">Discourse</Button>
   <Button
-    href="https://app.element.io/#/room/#cuda:nixos.org"
+    href="https://matrix.to/#/#cuda:nixos.org"
     color="semidarkblue" size="sm">Matrix</Button>
   <Button
     href="https://github.com/orgs/NixOS/projects/27"

--- a/src/content/teams/11_documentation.mdx
+++ b/src/content/teams/11_documentation.mdx
@@ -39,7 +39,7 @@ contact:
 - name: Discourse
   href: https://discourse.nixos.org/c/dev/documentation/25
 - name: Matrix
-  href: https://app.element.io/#/room/#docs:nixos.org
+  href: https://matrix.to/#/#docs:nixos.org
 - name: GitHub project board
   href: https://github.com/orgs/NixOS/projects/15
 ---
@@ -72,7 +72,7 @@ import Button from "../../components/ui/Button.astro";
     href="https://discourse.nixos.org/c/dev/documentation/25"
     color="semidarkblue" size="sm">Discourse</Button>
   <Button 
-    href="https://app.element.io/#/room/#docs:nixos.org"
+    href="https://matrix.to/#/#docs:nixos.org"
     color="semidarkblue" size="sm">Matrix</Button>
   <Button 
     href="https://github.com/orgs/NixOS/projects/15"


### PR DESCRIPTION
This gives users the choice to use their own Matrix client instead of Element, and it also shows a nicer landing page instead of immediately going to the Element web app. This is already used for most of the Matrix links, there are just a few which use app.element.io.

Builds successfully and all affected links seem to work correctly. I've copied the links below if you would like to try them:
- https://matrix.to/#/#docs:nixos.org
- https://matrix.to/#/#cuda:nixos.org
- https://matrix.to/#/#foundation:nixos.org

Old link for comparison:
- https://app.element.io/#/room/#docs:nixos.org