### PR TITLE
readme: fix workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Source for nixos.org
 
-[![GitHub Workflow Status of master branch](https://img.shields.io/github/workflow/status/nixos/nixos-homepage/Build%20&%20Deploy%20to%20Netlify?style=flat)](https://github.com/NixOS/nixos-homepage/actions?query=workflow%3A%22Build+%26+Deploy+to+Netlify%22) [![Number of open GitHub issues](https://img.shields.io/github/issues/nixos/nixos-homepage?style=flat&color=red)](https://github.com/nixos/nixos-homepage/issues) [![Number of open GitHub pull requests](https://img.shields.io/github/issues-pr/nixos/nixos-homepage?style=flat&color=blue)](https://github.com/nixos/nixos-homepage/pulls) [![Month of last commit](https://img.shields.io/github/last-commit/NixOS/nixos-homepage?style=flat)](https://github.com/NixOS/nixos-homepage/commits/master) [![Number of all contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat)](https://github.com/nixos/nixos-homepage#how-to-help)
+[![GitHub Workflow Status of master branch](https://img.shields.io/github/actions/workflow/status/nixos/nixos-homepage/cron.yml?branch=master&style=flat)](https://github.com/NixOS/nixos-homepage/actions/workflows/cron.yml?query=branch%3Amaster)
+[![Number of open GitHub issues](https://img.shields.io/github/issues/nixos/nixos-homepage?style=flat&color=red)](https://github.com/nixos/nixos-homepage/issues)
+[![Number of open GitHub pull requests](https://img.shields.io/github/issues-pr/nixos/nixos-homepage?style=flat&color=blue)](https://github.com/nixos/nixos-homepage/pulls)
+[![Month of last commit](https://img.shields.io/github/last-commit/NixOS/nixos-homepage?style=flat)](https://github.com/NixOS/nixos-homepage/commits/master)
+[![Number of all contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat)](https://github.com/nixos/nixos-homepage#how-to-help)
 
 Code and content for the [nixos.org](https://nixos.org) website.
 


### PR DESCRIPTION
Following the instructions at https://github.com/badges/shields/issues/8671. I have also formatted the badges into separate lines for better diffing in future.

I'm a little confused on the presence of both master and main branches, but I follow the label and other badges and direct this badge at the master branch.