### PR TITLE
Fix YAML for cron workflow

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -12,7 +12,7 @@ jobs:
     name: "Hourly build & deploy"
     runs-on: "ubuntu-latest"
 
-    if: !contains(github.event.head_commit.message, '[ci skip]')
+    if: ${{ ! contains(github.event.head_commit.message, '[ci skip]') }}
 
     steps:
       - name: "Checking out the repository"


### PR DESCRIPTION
I noticed the [cron workflow](https://github.com/NixOS/nixos-homepage/actions/workflows/cron.yml) has been broken for a while, when I was looking into whether some changes I made on the Nixpkgs/NixOS manual had already propagated to the homepage.

The YAML file had an error because it started the `if` condition with a `!` without escaping it. The [GitHub docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif) mention this case:

> You must always use the ${{ }} expression syntax or escape with '', "", or () when the expression starts with !, since ! is reserved notation in YAML format.

This PR fixes this by following the same syntax as shown in the example in the GitHub docs link above.