### PR TITLE
Show shell prompt in macOS install instructions

### DIFF
--- a/src/content/download/02-nix-macos.mdx
+++ b/src/content/download/02-nix-macos.mdx
@@ -9,7 +9,7 @@ platform: macos
 Install Nix via the **recommended** [multi-user installation](/manual/nix/stable/installation/multi-user):
 
 ```bash
-sh <(curl -L https://nixos.org/nix/install)
+$ sh <(curl -L https://nixos.org/nix/install)
 ```
 
 We believe we have ironed out how to cleanly support the read-only root on modern macOS. Please [consult the manual](/manual/nix/stable/installation/installing-binary#macos-installation) on details what the installation script does.


### PR DESCRIPTION
This bugged me on the download page, so I know it'll bug others. Every set of instructions for the other platforms shows the `$` prompt (or [other prompt where relevant](https://github.com/NixOS/nixos-homepage/blob/main/src/content/download/04-nix-docker.mdx)), but the macOS one doesn't. 

This commit just adds a `$ ` for consistency. 

Seemed like a simple enough change that I just opened a PR; let me know if there needs to be a corresponding issue.