### PR TITLE
Update meetups

### DIFF
--- a/src/content/community/meetups.yaml
+++ b/src/content/community/meetups.yaml
@@ -5,8 +5,6 @@ america:
     location: Reston (Virginia)
   - href: http://www.meetup.com/Bay-Area-Nix-NixOS-User-Group/
     location: San Francisco (California)
-  - href: https://www.meetup.com/Seattle-Nix-NixOS-and-Guix-GuixSD-Users/
-    location: Seattle (Washington)
 europe:
   - href: http://www.meetup.com/Amsterdam-Nix-Meetup/
     location: Amsterdam (Netherlands)
@@ -14,9 +12,7 @@ europe:
     location: Berlin (Germany)
   - href: https://www.meetup.com/Greater-Copenhagen-NixOS-User-Group
     location: Copenhagen (Denmark)
-  - href: https://www.meetup.com/Suisse-Romande-NixOS-User-Group/
-    location: Lausanne (Switzerland)
-  - href: https://www.meetup.com/NixOS-London/
+  - href: https://www.eventbrite.co.uk/e/london-nix-user-group-tickets-729796249227
     location: London (United Kingdom)
   - href: https://mobilizon.fr/@nix-mtp
     location: Montpellier (France)


### PR DESCRIPTION
London group seems to have relocated to Eventbrite. 

Removing Lausanne and Seattle as they seem to have closed.

Migrated changes from #1244