### PR TITLE
well-known: delegate matrix client/server to matrix.nixos.org

### DIFF
--- a/public/well-known/matrix/client
+++ b/public/well-known/matrix/client
@@ -1,8 +1,5 @@
 {
     "m.homeserver": {
-        "base_url": "https://nixos.ems.host"
-    },
-    "m.identity_server": {
-        "base_url": "https://vector.im"
+        "base_url": "https://matrix.nixos.org"
     }
 }

--- a/public/well-known/matrix/server
+++ b/public/well-known/matrix/server
@@ -1,3 +1,3 @@
 {
-    "m.server": "nixos.ems.host:443"
+    "m.server": "matrix.nixos.org:443"
 }


### PR DESCRIPTION
We are moving away from EMS and towards self-hosted infrastructure.

cc NixOS/infra#336

Migrated from PR #1218