### PR TITLE
docs team: Remove @asymmetric

### DIFF
--- a/src/content/teams/11_documentation.mdx
+++ b/src/content/teams/11_documentation.mdx
@@ -14,9 +14,6 @@ members:
 - name: henrik-ch
   discourse: henrik-ch
   title:
-- name: asymmetric
-  discourse: asymmetric
-  title:
 - name: wamirez
   discourse: wamirez
   title:


### PR DESCRIPTION
@asymmetric is voluntarely leaving the team due to time constraints (indicated in the private docs team Matrix room), thanks for your work, and feel free to rejoin at any point!