### PR TITLE
Make asciinema responsive with fit: width

### DIFF
--- a/public/demos/cover.scenario
+++ b/public/demos/cover.scenario
@@ -1,4 +1,4 @@
-#! { "step": 0.10, "width": 77, "height": 20 }
+#! { "step": 0.10, "width": 81, "height": 20 }
 
 # Instructions:
 # * empty lines will be skipped

--- a/public/demos/example_1.scenario
+++ b/public/demos/example_1.scenario
@@ -1,4 +1,4 @@
-#! { "step": 0.10, "width": 77, "height": 20 }
+#! { "step": 0.10, "width": 81, "height": 20 }
 
 $ # Lets see if python is present on the system
 $ python --version

--- a/public/demos/example_2.scenario
+++ b/public/demos/example_2.scenario
@@ -1,4 +1,4 @@
-#! { "step": 0.10, "width": 77, "height": 20 }
+#! { "step": 0.10, "width": 81, "height": 20 }
 
 $ # Lets create an environment with multiple packages
 $ nix-shell -p python3 nodejs go rustc

--- a/public/demos/example_3.scenario
+++ b/public/demos/example_3.scenario
@@ -1,4 +1,4 @@
-#! { "step": 0.10, "width": 77, "height": 20 }
+#! { "step": 0.10, "width": 81, "height": 20 }
 
 $ # You can also persist your development environment.
 $ # Here is a short example with python and nodejs:

--- a/public/demos/example_4.scenario
+++ b/public/demos/example_4.scenario
@@ -1,4 +1,4 @@
-#! { "step": 0.10, "width": 77, "height": 20 }
+#! { "step": 0.10, "width": 81, "height": 20 }
 
 $ # We all love docker. But over time it can become tedious to write
 $ # reliable docker files.

--- a/public/demos/example_5.scenario
+++ b/public/demos/example_5.scenario
@@ -1,4 +1,4 @@
-#! { "step": 0.10, "width": 77, "height": 20 }
+#! { "step": 0.10, "width": 81, "height": 20 }
 
 $ # How hard would it be to build and configure an Amazon EC2 image?
 $ # Let us configure a Nginx to serve a "Welcome to nginx!" page, with a

--- a/public/demos/example_6.scenario
+++ b/public/demos/example_6.scenario
@@ -1,4 +1,4 @@
-#! { "step": 0.10, "width": 77, "height": 20 }
+#! { "step": 0.10, "width": 81, "height": 20 }
 
 $ # In this example we will look into how to test your NixOS configuration
 $ # We will create a simple configuration with the `hello` package installed

--- a/src/components/ui/Asciinema.astro
+++ b/src/components/ui/Asciinema.astro
@@ -16,7 +16,7 @@ const defaultSettings = {
   loop: true,
   controls: 'auto',
   fit: 'width',
-  //terminalFontFamily: 'Fira Code Variable',
+  terminalFontFamily: 'Fira Code Variable',
 };
 
 const {
@@ -59,7 +59,9 @@ const demoId = "asciinema-demo-" + src.split("/").pop().split(".")[0];
         settings.autoPlay = true;
       }
 
-      const player = AsciinemaPlayer.create(src, this, settings)
+      document.fonts.load('1em ' + settings.terminalFontFamily).then(() => {
+        const player = AsciinemaPlayer.create(src, this, settings)
+      });
 
       if (this.dataset.title) {
         document.getElementById(`${this.id}-link`).addEventListener("click", (e) => {

--- a/src/components/ui/Asciinema.astro
+++ b/src/components/ui/Asciinema.astro
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const defaultSettings = {
-  cols: 77,
+  cols: 81,
   rows: 24,
   autoPlay: false,
   loop: true,

--- a/src/components/ui/Asciinema.astro
+++ b/src/components/ui/Asciinema.astro
@@ -15,9 +15,8 @@ const defaultSettings = {
   autoPlay: false,
   loop: true,
   controls: 'auto',
-  fit: false,
-  terminalFontFamily: 'Fira Code Variable',
-  terminalFontSize: '0.6rem',
+  fit: 'width',
+  //terminalFontFamily: 'Fira Code Variable',
 };
 
 const {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -130,7 +130,7 @@ posts.sort((a, b) => {
               <div class="flex flex-col items-start gap-2 overflow-hidden">
                 <Asciinema
                   title={demo.title}
-                  class="max-w-full self-center md:self-start"
+                  class="w-full self-center md:self-start"
                   src={demo.file}
                   settings={{
                     poster: 'npt:0:00:30',


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixos-homepage/issues/1323

Let asciinema handle responsive design by setting `fit: 'width'`

https://docs.asciinema.org/manual/player/options/#fit

This is the default option but it is currently false.

It seems like we need to make a tradeoff between fitting all the text in
or having a larger font. I'm betting on showing all the content being
the more important of the two and that we can have terminal replays with fewer columns
if we really want larger font. And it's easier to rely on asciinema's
player to be responsive than to adjust font size manually ourselves.

- deleted `terminalFontSize` per docs that this is only relevant if fit is set to false.

- Set width to 100% instead of max-width for the asciinema examples
  `max-width: 100%` resulted in these player elements getting a width of 0 after setting player fit to width

- Use font loading API to block on font loading before mounting AsciinemaPlayer

  Trying to use Fira Code Variable was causing asciinema player elements to cut text off (at least in Firefox and Safari).

  Per the note on the bottom of https://docs.asciinema.org/manual/player/fonts/
  ```
  The player performs measurement of font metrics (width/height) when it mounts in the page, therefore it's highly recommended to ensure chosen font is already loaded before calling create. This can be achieved >
  ```

  To verify this fix, it's best to observe the network tab for font transfers with Disable Caches checked to verify that the layout issue happens when the font isn't retrieved from the cache.

- Set width of every scenario to 81
  
  This is the longest line out of all the scenarios when running `wc -L *.scenario`

  Although that's the only scenario that has a line that is 81 characters wide, per the documentation here https://docs.asciinema.org/manual/player/options/#cols

  > It's recommended to set it to the same value as in asciicast file to avoid player resizing itself from 80x24 to actual dimensions of the recording when it gets loaded.

  so I just set it to 81 for all of them for simplicity
  
  
 ## Screenshots (from iOS)
 
 ### Before
<img src="https://github.com/NixOS/nixos-homepage/assets/217050/b2cfdff0-af4f-4a1d-a0bd-027aad12eadd" width="300" />
<img src="https://github.com/NixOS/nixos-homepage/assets/217050/11140851-4fe5-43ee-81c6-a3301be95f90" width="300" />

### After
<img src="https://github.com/NixOS/nixos-homepage/assets/217050/52c013ff-dffe-4e07-ba62-8041dea169e1" width="300" />
<img src="https://github.com/NixOS/nixos-homepage/assets/217050/eca85701-f675-454e-9902-6c6e5f68a83d" width="300" />

So although there's a big improvement in being able to see the entire width of the terminal, for the top example there is still some bleeding of the terminal text into the border. This looks like it is only happening on Safari/webkit both on mobile and desktop. Chrome/Firefox look OK on mobile and desktop.

I opened https://github.com/asciinema/asciinema-player/issues/258 to double check if I'm doing something wrong and/or if there is a workaround
