### PR TITLE
Fix nix pills build with new mdBook output

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
     "nix-pills": {
       "flake": false,
       "locked": {
-        "lastModified": 1708416248,
-        "narHash": "sha256-eSc56ZexbYtejnN7uHaMpLrNQdeloyv18Ra5RT+gZAE=",
+        "lastModified": 1712619431,
+        "narHash": "sha256-viqCSq84ulhI2Q1THzllSkQZte57RcnMvepYXOiNf5g=",
         "owner": "NixOS",
         "repo": "nix-pills",
-        "rev": "102ef96805e186aec93a18e16da8355fbd89c6d9",
+        "rev": "403304578200457addf6b4a5da926f94a11b3bfc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,6 @@ rec {
 
         nixPills = import nix-pills {
           inherit pkgs;
-          revCount = nix-pills.lastModifiedDate; # FIXME
-          shortRev = nix-pills.shortRev;
         };
 
         # TODO: change structure to conform to ./src/content/download/aws-ec2.yaml but in json


### PR DESCRIPTION
Since https://github.com/NixOS/nix-pills/pull/233 got merged, the nix pills are now built with mdBook. In this process, we removed the `revCount` and `shortRev` attributes from the mdBook output.

This PR removes those attributes from here to ensure the nix pills can still be built with the new changes.