### PR TITLE
Update README.md, correcting an invalid hyperlink to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Workflow Status of master branch](https://img.shields.io/github/actions/workflow/status/nixos/nixos-homepage/cron.yml?branch=master&style=flat)](https://github.com/NixOS/nixos-homepage/actions/workflows/cron.yml?query=branch%3Amaster)
 [![Number of open GitHub issues](https://img.shields.io/github/issues/nixos/nixos-homepage?style=flat&color=red)](https://github.com/nixos/nixos-homepage/issues)
 [![Number of open GitHub pull requests](https://img.shields.io/github/issues-pr/nixos/nixos-homepage?style=flat&color=blue)](https://github.com/nixos/nixos-homepage/pulls)
-[![Month of last commit](https://img.shields.io/github/last-commit/NixOS/nixos-homepage?style=flat)](https://github.com/NixOS/nixos-homepage/commits/master)
+[![Month of last commit](https://img.shields.io/github/last-commit/NixOS/nixos-homepage?style=flat)](https://github.com/NixOS/nixos-homepage/commits/main)
 [![Number of all contributors](https://img.shields.io/badge/all_contributors-10-orange.svg?style=flat)](https://github.com/nixos/nixos-homepage#how-to-help)
 
 Code and content for the [nixos.org](https://nixos.org) website.


### PR DESCRIPTION
changed link from `master` to `main` to correctly refer to the main branch