### PR TITLE
Make team member links distinguishable by an Icon

### DIFF
--- a/src/content/teams/07_marketing.mdx
+++ b/src/content/teams/07_marketing.mdx
@@ -4,6 +4,7 @@ description: Maintains this website, responsible for social media outreach, coll
 members:
 - name: Rok Garbas
   discourse: garbas
+  github: garbas
   title: Leader
 - name: Thomas Bereknyei
   discourse: tomberek
@@ -16,9 +17,11 @@ members:
   title:
 - name: Dan Baker
   discourse: djacu
+  github: djacu
   title:
 - name: Thilo Billerbeck
   discourse: avocadoom
+  github: thilobillerbeck
   title:
 contact:
 - name: Discourse

--- a/src/pages/community/teams/[...slug].astro
+++ b/src/pages/community/teams/[...slug].astro
@@ -5,6 +5,7 @@ import Layout from "../../../layouts/Layout.astro";
 import PageHeader from "../../../components/layout/PageHeader.astro";
 import Container from "../../../components/layout/Container.astro";
 import Tag from "../../../components/ui/Tag.astro";
+import { Icon } from "astro-icon/components";
 
 export async function getStaticPaths() {
   const teamEntries = await getCollection("teams");
@@ -30,20 +31,36 @@ const { Content } = await entry.render();
           entry.data.members.map((member) => (
             <li class="mb-1 last:mb-0">
               {member.name}
-              {member.discourse && (
-                <>
-                (<a href={"https://discourse.nixos.org/u/" + member.discourse}>@{member.discourse}</a>)
-                </>
-              )}
-              {member.github && (
-                <>
-                (<a href={"https://github.com/" + member.github}>@{member.github}</a>)
-                </>
-              )}
               {member.title && (
                 <>
                 &mdash;
                 {member.title}
+                </>
+              )}
+              {member.discourse && (
+                <br />
+                <>
+                  <a href={"https://discourse.nixos.org/u/" + member.discourse}>
+                    <Icon
+                      name="simple-icons:discourse"
+                      alt="logo of discourse"
+                      class="inline-block"
+                    />
+                    @{member.discourse}
+                  </a>
+                </>
+              )}
+              {member.github && (
+                <br />
+                <>
+                  <a href={"https://github.com/" + member.github}>
+                    <Icon
+                      name="simple-icons:github"
+                      alt="logo of github"
+                      class="inline-block"
+                    />
+                    @{member.github}
+                  </a>
                 </>
               )}
             </li>


### PR DESCRIPTION
Closes https://github.com/NixOS/nixos-homepage/issues/1336

- Display github/discourse icons next to member links
- Need to set `inline-block` to display the icons inline without unnecessary line breaks
- Moved title higher and added line breaks in between name and links to better accommodate multiple links
- Also added some github examples for the marketing team so we can see what it looks like if there are both
