### PR TITLE
Fix Eelco's Nix team title

### DIFF
--- a/src/content/teams/10_nix.mdx
+++ b/src/content/teams/10_nix.mdx
@@ -4,7 +4,7 @@ description: Maintains and releases the Nix package manager.
 members:
 - name: Eelco Dolstra
   discourse: edolstra
-  title: Team lead
+  title:
 - name: Théophane Hufschmitt
   discourse: thufschmitt
   title:


### PR DESCRIPTION
Having spoken with Nix team members, it looks like all are equally empowered, and that it's inaccurate to call Eelco the team lead.

See also https://discourse.nixos.org/t/nixos-foundation-board-giving-power-to-the-community/44552/7?u=infinisil

Ping @NixOS/nix-team, please review