### PR TITLE
Update RFC Steering Committee after jonringer stepped down

### DIFF
--- a/src/content/teams/02_rfc-steering-committee.mdx
+++ b/src/content/teams/02_rfc-steering-committee.mdx
@@ -10,8 +10,6 @@ members:
   discourse: infinisil
 - name: Priyanshu Tripathi
   discourse: GetPsyched
-- name: Jonathan Ringer
-  discourse: jonringer
 - name: Matthias Meschede
   discourse: mat
 contact:


### PR DESCRIPTION
@jonringer has voluntarely stepped down from the committee with a message in the internal Matrix channel.

I thank you for your time on the steering committee, even if it was just brief!