### PR TITLE
Proofreading "How Nix Works"

### DIFF
--- a/src/pages/guides/how-nix-works.mdx
+++ b/src/pages/guides/how-nix-works.mdx
@@ -79,7 +79,7 @@ Nix expressions generally describe how to build a package from source, so an ins
 $ nix-env --install firefox
 ```
 
-_could_ cause quite a bit of build activity, as not only Firefox but also all its dependencies (all the way up to the C library and the compiler) would have to built, at least if they are not already in the Nix store. This is a _source deployment model_. For most users, building from source is not very pleasant as it takes far too long. However, Nix can automatically skip building from source and instead use a _binary cache_, a web server that provides pre-built binaries. For instance, when asked to build `/nix/store/b6gvzjyb2pg0…-firefox-33.1` from source, Nix would first check if the file http://cache.nixos.org/b6gvzjyb2pg0….narinfo exists, and if so, fetch the pre-built binary referenced from there; otherwise, it would fall back to building from source.
+_could_ cause quite a bit of build activity, as not only Firefox but also all its dependencies (all the way up to the C library and the compiler) would have to be built, at least if they are not already in the Nix store. This is a _source deployment model_. For most users, building from source is not very pleasant as it takes far too long. However, Nix can automatically skip building from source and instead use a _binary cache_, a web server that provides pre-built binaries. For instance, when asked to build `/nix/store/b6gvzjyb2pg0…-firefox-33.1` from source, Nix would first check if the file http://cache.nixos.org/b6gvzjyb2pg0….narinfo exists, and if so, fetch the pre-built binary referenced from there; otherwise, it would fall back to building from source.
 
 Nix Packages collection
 -----------------------


### PR DESCRIPTION
This pull request adds a missing "be" to the body of ["How Nix Works"](https://github.com/NixOS/nixos-homepage/blob/022865693e96ea1c32335c18aecd93388ce9dd2a/src/pages/guides/how-nix-works.mdx).