### PR TITLE
50-nixos-isoimage: Reference plasma6 ISOs for 24.05

### DIFF
--- a/src/content/download/50-nixos-isoimage.mdx
+++ b/src/content/download/50-nixos-isoimage.mdx
@@ -41,8 +41,8 @@ The graphical installation ISO image **contains the graphical NixOS installer** 
   <span>
     <Button
       color="semidarkblue"
-      href={nixosDownloadLink("plasma5", "x86_64-linux", "iso", false)}
-      shaHref={nixosDownloadLink("plasma5", "x86_64-linux", "iso", true)}
+      href={nixosDownloadLink("plasma6", "x86_64-linux", "iso", false)}
+      shaHref={nixosDownloadLink("plasma6", "x86_64-linux", "iso", true)}
       shaText="(SHA-256)"
       size="sm-mobfull"
       classList = {["w-full", "md:w-auto", "block", "md:inline", "text-center", "md:text-left"]}
@@ -52,8 +52,8 @@ The graphical installation ISO image **contains the graphical NixOS installer** 
   <span>
     <Button
       color="semidarkblue"
-      href={nixosDownloadLink("plasma5", "aarch64-linux", "iso", false)}
-      shaHref={nixosDownloadLink("plasma5", "aarch64-linux", "iso", true)}
+      href={nixosDownloadLink("plasma6", "aarch64-linux", "iso", false)}
+      shaHref={nixosDownloadLink("plasma6", "aarch64-linux", "iso", true)}
       shaText="(SHA-256)"
       size="sm-mobfull"
       classList = {["w-full", "md:w-auto", "block", "md:inline", "text-center", "md:text-left"]}


### PR DESCRIPTION
The ISO name will change slightly due to the update from KDE Plasma version 5 to 6.

Blocked until we switch to 24.05 downloads on the homepage.