### PR TITLE
redirect all Nix manual URLs to nix.dev

### DIFF
--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -113,44 +113,8 @@
   force = true
 
 [[redirects]]
-  from = "/manual/nix"
-  to = "/manual/nix/stable"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/:version/expressions/expression-language.html"
-  to = "/manual/nix/:version/language/index.html"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/:version/expressions/language-values.html"
-  to = "/manual/nix/:version/language/values.html"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/:version/expressions/language-constructs.html"
-  to = "/manual/nix/:version/language/constructs.html"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/:version/expressions/language-operators.html"
-  to = "/manual/nix/:version/language/operators.html"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/:version/expressions/*"
-  to = "/manual/nix/:version/language/:splat"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/:version/package-management/channels.html"
-  to = "/manual/nix/:version/command-ref/nix-channel.html"
+  from = "/manual/nix/*"
+  to = "https://nix.dev/manual/nix/stable/:splat"
   status = 302
   force = true
 


### PR DESCRIPTION
nix.dev serves stable URLs to the manual, and has redirects for the
`stable` and `unstable` mutable URLs. it also re-uses page-level
redirects that are supplied by the Nix manual itself, so we don't have
to take care of that here any more.

Made with @roberth at #ZurichZHF