### PR TITLE
fix redirects once again

### DIFF
--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -107,30 +107,6 @@
   force = true
 
 [[redirects]]
-  from = "/manual"
-  to = "/learn.html"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/*"
-  to = "https://nix.dev/manual/nix/stable/:splat"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nixpkgs"
-  to = "/manual/nixpkgs/stable"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nixos"
-  to = "/manual/nixos/stable"
-  status = 302
-  force = true
-
-[[redirects]]
   from = "/nixos/nix-pills/*"
   to = "/guides/nix-pills/:splat"
   status = 302
@@ -215,14 +191,27 @@
   force = true
 
 [[redirects]]
-  from = "/nix/manual/unstable/*"
-  to = "/manual/nix/development/:splat"
+  from = "/manual"
+  to = "/learn.html"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/nix/manual/stable/*"
-  to = "/manual/nix/latest/:splat"
+  # these rather old links are still used in the Nixpkgs manual
+  from = "/nix/manual/*"
+  to = "https://nix.dev/manual/nix/stable/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/manual/nix/stable/*"
+  to = "https://nix.dev/manual/nix/latest/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/nix/manual/unstable/*"
+  to = "https://nix.dev/manual/nix/development/:splat"
   status = 302
   force = true
 
@@ -233,8 +222,20 @@
   force = true
 
 [[redirects]]
+  from = "/manual/nixpkgs"
+  to = "/manual/nixpkgs/stable"
+  status = 302
+  force = true
+
+[[redirects]]
   from = "/nixos/manual/*"
   to = "/manual/nixos/stable/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/manual/nixos"
+  to = "/manual/nixos/stable"
   status = 302
   force = true
 


### PR DESCRIPTION
1f1fbfcac16f2aec357b5a39e7bcc2416fc9d43b and 5f00e553a8230ead255ee6b1f3d274fc4f6bb727 were a confused about old and new URL formats, and it didn't help that very similar-looking redirects were in multiple locations of the file.

this change brings them together and should restore all existing URLs and correctly point them to nix.dev.

closes #1448 - sorry everyone for the disruption, and thanks again for pointing out the breakages. ping me directly if anything else around the Nix manual falls apart.