### PR TITLE
fix confusing redirects

### DIFF
--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -204,13 +204,19 @@
   force = true
 
 [[redirects]]
+  from = "/manual/nix"
+  to = "https://nix.dev/manual/nix/latest/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
   from = "/manual/nix/stable/*"
   to = "https://nix.dev/manual/nix/latest/:splat"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/nix/manual/unstable/*"
+  from = "/manual/nix/unstable/*"
   to = "https://nix.dev/manual/nix/development/:splat"
   status = 302
   force = true


### PR DESCRIPTION
undo another error introduced in rewiring the Nix manual URLs.

Discovered by @GreatTeacherOni https://github.com/NixOS/nix/issues/9349#issuecomment-2143051011, thanks!