### PR TITLE
Fix redirect for hydra manual

### DIFF
--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -452,7 +452,7 @@
 
 [[redirects]]
   from  = "/hydra/manual"
-  to = "https://hydra.nixos.org/job/hydra/master/manual/latest/download-by-type/doc/manual"
+  to = "https://hydra.nixos.org/job/hydra/master/manual.x86_64-linux/latest/download-by-type/doc/manual"
   status = 302
   force = true
 


### PR DESCRIPTION
The redirect for the hydra manual link points to the job "manual" which seems to have been deleted in 2022, replaced by "manual.x86_64-linux" and "manual.aarch64-linux".

I don't know how much the manuals differ by architecture, if at all, but I'm guessing x86-64 is reasonable target here.