### PR TITLE
Change Github Actions trigger type to pull_request_target to prevent tampering and allow workflow from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: "write"


### PR DESCRIPTION
Changing the deploy trigger to `pull_request_target` to allow the CI to use our secrets for deployments regarding PRs from forks, making PR checks quicker and less error prone over time.

See here for details: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target