### PR TITLE
fix more broken URLs

### DIFF
--- a/public/netlify.toml
+++ b/public/netlify.toml
@@ -197,27 +197,45 @@
   force = true
 
 [[redirects]]
-  # these rather old links are still used in the Nixpkgs manual
-  from = "/nix/manual/*"
+  from = "/manual/nix/stable/*"
   to = "https://nix.dev/manual/nix/stable/:splat"
   status = 302
   force = true
 
 [[redirects]]
-  from = "/manual/nix/*"
-  to = "https://nix.dev/manual/nix/latest/:splat"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/manual/nix/stable/*"
-  to = "https://nix.dev/manual/nix/latest/:splat"
-  status = 302
-  force = true
-
-[[redirects]]
   from = "/manual/nix/unstable/*"
-  to = "https://nix.dev/manual/nix/development/:splat"
+  to = "https://nix.dev/manual/nix/latest/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
+  # catch links to the top-level
+  from = "/manual/nix"
+  # this must not have a trailing slash!
+  # otherwise, CSS won't be loaded
+  to = "https://nix.dev/manual/nix"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/manual/nix/*"
+  to = "https://nix.dev/manual/nix/:splat"
+  status = 302
+  force = true
+
+# these rather old links are still used in the Nixpkgs manual
+[[redirects]]
+  # catch links to the top-level
+  from = "/nix/manual"
+  # this must not have a trailing slash!
+  # otherwise, CSS won't be loaded
+  to = "https://nix.dev/manual/nix"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "/nix/manual/*"
+  to = "https://nix.dev/manual/nix/:splat"
   status = 302
   force = true
 


### PR DESCRIPTION
Tested with netlify-cli!

Note that this changes semantics, and now redirects `unstable` to the latest Nix version rather than to the most recent build from `master`.
This is to avoid
- either more downstream errors with "pretty URLs", which are not supported by Hydra
- or expensively re-building the manual on nix.dev regularly just to work around Hydra's limitations

This is probably what we want.
I assume that most people will use the latest Nix release rather than `master`.
For those who live on `master` there's still https://nix.dev/manual/nix/development, and presumably being power users they will hopefully know that.

Closes:
- https://github.com/NixOS/nix.dev/issues/1005
- https://github.com/NixOS/nix.dev/issues/1006
- https://github.com/NixOS/nixos-homepage/issues/1483
- https://github.com/NixOS/nix.dev/issues/996
- https://discourse.nixos.org/t/avoid-string-interpolation-nix/30772/9

Thanks everyone for participating in this involuntary scream test, continuing our year-long tradition of compaint-based, anger-driven development. ;)