### PR TITLE
calendar: fix grid columns

### DIFF
--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -217,7 +217,7 @@ import nixosFoundationLogo from "../assets/image/nixos-foundation-logo.svg";
         </h3>
         <p class="text-gray-700">
           We use these calendars to schedule events, meetings, and other.
-          <ul class="grid grid-cols-1 gap-4 mt-4 flex-wrap">
+          <ul class="grid grid-cols-3 gap-4 mt-4 flex-wrap">
             {
               calendarsMain.map((platform) => (
                 <OfficialCommunityLink


### PR DESCRIPTION
Requested that the calendars don't take up the full width but use a 3 column grid like the rest of the elemnts.
https://github.com/NixOS/nixos-homepage/pull/1488#issuecomment-2198243157

![image](https://github.com/NixOS/nixos-homepage/assets/7043297/e24e6e42-8ef1-4fbf-a3ac-837573a1b5e6)
