### PR TITLE
fix: broken link to language overview in manual

### DIFF
--- a/src/content/learning-manuals/01-nix-manual.mdx
+++ b/src/content/learning-manuals/01-nix-manual.mdx
@@ -13,7 +13,7 @@ Nix is a package manager which comes in a form of many command line tools. Packa
   - [nix-build](/manual/nix/stable/command-ref/nix-build) — build a Nix expression
   - [nix-shell](/manual/nix/stable/command-ref/nix-shell) — start an interactive shell based on a Nix expression
   - [nix-store](/manual/nix/stable/command-ref/nix-store) — manipulate or query the Nix store
-- [Nix expression language](/manual/nix/stable/expressions/expression-language.html)
+- [Nix expression language](/manual/nix/stable/language/index.html)
   - [Built-in functions](/manual/nix/stable/expressions/builtins.html)
   - [Nixpkgs Library Functions](/manual/nixpkgs/stable/#sec-functions-library)
   - [Debugging Nix Expressions](/manual/nixpkgs/stable/#sec-debug)


### PR DESCRIPTION
Seems like [the link](https://nixos.org/manual/nix/stable/expressions/expression-language.html) to the language docs on https://nixos.org/learn is dead. Checked with archive.org and it used to redirect to https://nixos.org/manual/nix/stable/language/index.html so I updated it.