### PR TITLE
add link to Nix team meeting information

### DIFF
--- a/src/content/teams/10_nix.mdx
+++ b/src/content/teams/10_nix.mdx
@@ -48,7 +48,7 @@ This includes, but isn’t limited to:
 
 ## Meetings
 
-The Nix team has a weekly meeting to triage and discuss issues and PRs, and a
+[The Nix team meets regularly](https://github.com/NixOS/nix/tree/master/maintainers#meeting-protocol) to triage and discuss issues and PRs, and a
 weekly working session to review PRs and hack on code.
 
 ## Links


### PR DESCRIPTION
this information has been asked for repeatedly and otherwise requires
finding the right link and traversing a fairly large document to access.