### PR TITLE
teams/security: update link to the security announcement category on Discourse

### DIFF
--- a/src/content/teams/03_security.mdx
+++ b/src/content/teams/03_security.mdx
@@ -15,7 +15,7 @@ contact:
   - name: Matrix
     href: https://matrix.to/#/#security:nixos.org
   - name: Discourse
-    href: https://discourse.nixos.org/c/dev/security
+    href: https://discourse.nixos.org/c/announcements/security
 ---
 
 # Sources of Security Information
@@ -24,7 +24,7 @@ Security is a priority for the NixOS community. A variety of channels are used t
 
 - The issues tagged "Security" on [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%221.severity%3A+security%22)
 - The [Matrix room](https://matrix.to/#/#security:nixos.org)
-- The NixOS security [Discourse](https://discourse.nixos.org/c/dev/security)
+- The announcements on NixOS security [Discourse](https://discourse.nixos.org/c/announcements/security)
 
 In addition to community-sourced developments, NixOS has a dedicated security team. If the above sources are not enough to answer your question, please reach out to the team.
 


### PR DESCRIPTION
Announcements are now made in a distinct category.