### PR TITLE
teams/xen: fix typo

### DIFF
--- a/src/content/teams/14_xen.mdx
+++ b/src/content/teams/14_xen.mdx
@@ -1,6 +1,6 @@
 ---
 name: Xen Project Hypervisor Team
-description: Maintains the Xen Project Hypervisor tooling and the accompaniying NixOS modules.
+description: Maintains the Xen Project Hypervisor tooling and the accompanying NixOS modules.
 members:
   - name: Fernando Rodrigues
     discourse: sigmasquadron


### PR DESCRIPTION
I have no idea how I only noticed this after the merge. I'm truly sorry.