### PR TITLE
Mention the source of truth for the values

### DIFF
--- a/src/pages/values.astro
+++ b/src/pages/values.astro
@@ -8,6 +8,8 @@ import Divider from "../components/layout/Divider.astro";
 
 import Citation from "../components/ui/Citation.astro";
 import Quotation from "../components/ui/Quotation.astro";
+
+// The source of truth for this document is https://github.com/NixOS/org/blob/main/doc/values.md.
 ---
 
 <Layout title="Values">


### PR DESCRIPTION
Small follow-up to https://github.com/NixOS/nixos-homepage/pull/1541 now that the more long-term https://github.com/NixOS/org/blob/main/doc/values.md exists.

The intention is that people don't update the values by making a PR to the homepage, but rather the other repo.