### PR TITLE
blog: show post names in titles

### DIFF
--- a/src/pages/blog/[category]/[year]/[id].astro
+++ b/src/pages/blog/[category]/[year]/[id].astro
@@ -20,7 +20,7 @@ const { entry } = Astro.props;
 const { Content } = await entry.render();
 ---
 
-<Layout title="Blog">
+<Layout title=`${entry.data.title} | Blog`>
   <PageHeader
     text={entry.data.title}
     subtext={entry.data.date


### PR DESCRIPTION
The change in this PR shows the blog post title in the page title. Closes #727. 