### PR TITLE
astro: don't set up file watchers for direnv

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -34,5 +34,12 @@ export default defineConfig({
       theme: syntaxTheme,
     },
   },
+  vite: {
+    server: {
+      watch: {
+        ignored: ['**/.direnv/**']
+      }
+    }
+  },
   compressHTML: true,
 });


### PR DESCRIPTION
astro would try to set up inotify watchers for all files in direnv, including but not exclusive to a full nixpkgs, which would spam errors like the following in the console and refuse to start:

Error: ENOSPC: System limit for number of file watchers reached, watch 'nixos-homepage/.direnv/flake-inputs/nk036dp7q03yqkikxlfsapljhgnhxkka-source/default.nix' (for each file in nixpkgs).
