### PR TITLE
marketing-team: update members and roles

### DIFF
--- a/src/content/teams/07_marketing.mdx
+++ b/src/content/teams/07_marketing.mdx
@@ -2,20 +2,23 @@
 name: Marketing Team
 description: Maintains this website, responsible for social media outreach, collects metrics. Help grow the Nix user base.
 members:
+  - name: Ida Bzo
+    discourse: idabzo
+    title: Lead
+  - name: Thilo Billerbeck
+    discourse: avocadoom
+    title: Webmaster
+  - name: Florian Pester
+    discourse: flyfloh
+    title: Social Media Liaison
+  - name: Daniel Baker
+    discourse: djacu
+    title: Surveys and Metrics Coordinator
   - name: Thomas Bereknyei
     discourse: tomberek
     title:
-  - name: Ida Bzo
-    discourse: idabzo
-    title:
   - name: Guillaume Desforges
     discourse: arsleust
-    title:
-  - name: Dan Baker
-    discourse: djacu
-    title:
-  - name: Thilo Billerbeck
-    discourse: avocadoom
     title:
 contact:
   - name: Discourse


### PR DESCRIPTION
Updates members and roles based on a recent marketing team meeting on 2025-01-13. https://github.com/NixOS/marketing/blob/3fb403ccd7982d09ef8c584660b67770003f7213/minutes/2025-01-13.md

- Adds Florian to the team.
- Adds roles based on the meeting.
- Re-organizes member order.