### PR TITLE
Moderation: update reporting issues section

### DIFF
--- a/src/content/teams/08_moderation.mdx
+++ b/src/content/teams/08_moderation.mdx
@@ -39,8 +39,13 @@ repository](https://github.com/NixOS/moderation).
 
 ## Reporting issues
 
-Contact any of the current team members directly, e.g. via Matrix, or through
-the Contact links.
+The preferred way to contact the team is via private message on the
+[NixOS Discourse](https://discourse.nixos.org/) using the
+[`@moderators`](https://discourse.nixos.org/g/moderators) group. This
+allows any member of the team to respond and participate.
+Alternatively, you can contact us via
+[email](mailto:moderation@nixos.org), or reach to any of the current
+team members individually via Matrix.
 
 The project team is obligated to maintain confidentiality with regard to the
 reporter of an incident.


### PR DESCRIPTION
We prefer being contacted via Discourse DM to make sure we can all have access to reports and prevent bottlenecks.