### PR TITLE
fix typo in frontmatter of 2019-04-17 newsletter

### DIFF
--- a/src/content/blog/newsletters/2019_07-nixos-19-03-release-ipfs-ci-integrations-and-documentation-feedback.md
+++ b/src/content/blog/newsletters/2019_07-nixos-19-03-release-ipfs-ci-integrations-and-documentation-feedback.md
@@ -1,7 +1,7 @@
 ---
-Title: '#07 - NixOS 19.03 release, IPFS, CI integrations and documentation feedback'
-Date: 2019-04-17
-Description: With pride, there are many curses. With humility, there come many blessings - Ezra Taft Benso
+title: '#07 - NixOS 19.03 release, IPFS, CI integrations and documentation feedback'
+date: 2019-04-17
+description: With pride, there are many curses. With humility, there come many blessings - Ezra Taft Benso
 ---
 
 # News


### PR DESCRIPTION
This is a technical fix in the frontmatter (metadata) of the newsletter dated 2019-04-17.
The properties starting in capital result in the `blog/feed.xml` showing incorrect details for the post.