### PR TITLE
Fix command in nixpkgs docker instructions

### DIFF
--- a/src/content/download/04-nix-docker.mdx
+++ b/src/content/download/04-nix-docker.mdx
@@ -22,6 +22,6 @@ The `workdir` example from above can be also used to start hacking on nixpkgs:
 ```bash
 $ git clone --depth=1 https://github.com/NixOS/nixpkgs.git
 $ docker run -it -v $(pwd)/nixpkgs:/nixpkgs nixos/nix
-docker> nix-build -I nixpkgs=/nixpkgs -A hello
+docker> nix-build -I nixpkgs=/nixpkgs -A hello nixpkgs/default.nix
 docker> find ./result # this symlink points to the build package
 ```


### PR DESCRIPTION
Closes: #1415 

I tested the commands in the docs on my local and they failed then I tested the edited commands in the issue reply by [@mcdonc](https://github.com/mcdonc) and they worked.
The original fails because we mount `/nixpkgs/` to `/nixpkgs` in the previous command `docker run -it -v $(pwd)/nixpkgs:/nixpkgs nixos/nix` instead of '/'. I think this is intentional, however it means that `default.nix` is located at `/nixpkgs/default.nix` and has to be specified in the `nix-build` command.