### PR TITLE
Fix sponsor SVGs on firefox

### DIFF
--- a/public/images/sponsors/4tu.svg
+++ b/public/images/sponsors/4tu.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 302.33 119.14">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 302.33 119.14" width="302.33" height="119.14">
   <defs>
     <style>.cls-1{fill:#a2a2a2;}.cls-2{fill:#f49120;}</style>
   </defs>

--- a/public/images/sponsors/equinix_metal.svg
+++ b/public/images/sponsors/equinix_metal.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg fill="none" viewBox="0 0 128 30" xmlns="http://www.w3.org/2000/svg">
+<svg fill="none" viewBox="0 0 128 30" xmlns="http://www.w3.org/2000/svg" width="128" height="30">
 <g clip-path="url(#a)">
 <path d="M76.2514 0H75.9493V29.52H76.2514V0Z" fill="#707073"/>
 <path d="m0 23.16v6.36h5.6796v-0.84h-4.7733v-2.04h3.0815v-0.84h-3.0815v-1.8h4.592v-0.84h-5.4983z" fill="#000"/>


### PR DESCRIPTION
Closes: #1661

Firefox actually renders the images but at 0x0 so it is not visible. Fixed by setting a width and height based on the svg's viewbox to display the image with a non 0x0 dimensions.