### PR TITLE
Remove nix doc generation form build process

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,9 +59,6 @@ rec {
           nix_stable = released-nix-stable.packages."${system}".nix;
           nix_unstable = released-nix-unstable.packages."${system}".nix;
 
-          nix_doc_stable = released-nix-stable.packages."${system}".nix-manual;
-          nix_doc_unstable = released-nix-unstable.packages."${system}".nix-manual;
-
           nodejs_current = pkgs.nodejs_20;
 
           nixPills = import nix-pills {
@@ -157,13 +154,6 @@ rec {
               ''
                 mkdir -p $out
                 ${redirectManualHTML "/learn" "$out/index.html"}
-
-                nix_dir=$PWD/nix && mkdir -p $nix_dir
-                cp -R --no-preserve=mode,ownership ${nix_doc_stable}/share/doc/nix/manual $nix_dir/stable
-                cp -R --no-preserve=mode,ownership ${nix_doc_unstable}/share/doc/nix/manual $nix_dir/unstable
-                ${manualVersionSwitch "$nix_dir" "stable"}
-                ${redirectManualHTML "/manual/nix/stable" "$nix_dir/index.html"}
-                mv $nix_dir $out
 
                 nixpkgs_dir=$PWD/nixpkgs && mkdir -p $nixpkgs_dir
                 cp -R --no-preserve=mode,ownership ${


### PR DESCRIPTION
Since the `nix` manual is now handled by nix.dev, this PR omits it from the website build process.