### PR TITLE
Fix broken channels link

### DIFF
--- a/src/content/learning-manuals/01-nix-manual.mdx
+++ b/src/content/learning-manuals/01-nix-manual.mdx
@@ -7,12 +7,12 @@ Nix is a package manager which comes in a form of many command line tools. Packa
 
 - [Installation](/manual/nix/stable/installation/installing-binary)
 - [Basic package management](/manual/nix/stable/package-management/basic-package-mgmt)
-- [What is a channel?](/manual/nix/stable/package-management/channels.html)
 - Main command line tools:
   - [nix-env](/manual/nix/stable/command-ref/nix-env) — manipulate or query Nix user environments
   - [nix-build](/manual/nix/stable/command-ref/nix-build) — build a Nix expression
   - [nix-shell](/manual/nix/stable/command-ref/nix-shell) — start an interactive shell based on a Nix expression
   - [nix-store](/manual/nix/stable/command-ref/nix-store) — manipulate or query the Nix store
+  - [nix-channel](/manual/nix/stable/command-ref/nix-channel) - keep Nix expressions up to date
 - [Nix expression language](/manual/nix/stable/language/index.html)
   - [Built-in functions](/manual/nix/stable/expressions/builtins.html)
   - [Nixpkgs Library Functions](/manual/nixpkgs/stable/#sec-functions-library)


### PR DESCRIPTION
The "What is a channel?" link in the manual goes to a page not found. I think `nix-channel` is close enough if that's meant to be kept around