### PR TITLE
download/nix/macos: add instruction to open terminal

### DIFF
--- a/src/content/download/02-nix-macos.mdx
+++ b/src/content/download/02-nix-macos.mdx
@@ -16,7 +16,8 @@ platform: macos
 >
 > when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
 
-Install Nix via the **recommended** [multi-user installation](/manual/nix/stable/installation/multi-user):
+Install Nix via the **recommended** [multi-user installation](/manual/nix/stable/installation/multi-user).
+Open a Terminal (by pressing [Cmd] + [Space] and typing `terminal`) and run the following command:
 
 ```bash
 $ sh <(curl -L https://nixos.org/nix/install)


### PR DESCRIPTION
This adds a sentence explaining to macOS users how to open the terminal. Fixes #1116.