### PR TITLE
Fix homepage build on macOS darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -169,12 +169,8 @@ rec {
                 mv $nixpkgs_dir $out
 
                 nixos_dir=$PWD/nixos && mkdir -p $nixos_dir
-                cp -R --no-preserve=mode,ownership ${
-                  released-nixpkgs-stable.htmlDocs.nixosManual.${system}
-                }/share/doc/nixos $nixos_dir/stable
-                cp -R --no-preserve=mode,ownership ${
-                  released-nixpkgs-unstable.htmlDocs.nixosManual.${system}
-                }/share/doc/nixos $nixos_dir/unstable
+                cp -R --no-preserve=mode,ownership ${released-nixpkgs-stable.htmlDocs.nixosManual.x86_64-linux}/share/doc/nixos $nixos_dir/stable
+                cp -R --no-preserve=mode,ownership ${released-nixpkgs-unstable.htmlDocs.nixosManual.x86_64-linux}/share/doc/nixos $nixos_dir/unstable
                 ${manualVersionSwitch "$nixos_dir" "stable"}
                 ${redirectManualHTML "/manual/nixos/stable" "$nixos_dir/index.html"}
                 mv $nixos_dir $out


### PR DESCRIPTION
`aarch64-darwin` does not exist under `htmlDocs.nixosManual` (which
makes sense because nixos would preclude darwin), so hardcode to
`x86_64-linux` instead.

Similar precedent https://github.com/NixOS/nixos-homepage/pull/1470

This fixes this error when running `npm run dev` inside the dev shell

```
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'manuals'
         whose name attribute is located at /nix/store/jl0f72iyvv0cj1r5qrqmpi9cvi1dfcxp-source/pkgs/stdenv/generic/make-derivation.nix:375:7

       … while evaluating attribute 'buildCommand' of derivation 'manuals'
         at /nix/store/jl0f72iyvv0cj1r5qrqmpi9cvi1dfcxp-source/pkgs/build-support/trivial-builders/default.nix:63:17:
           62|         enableParallelBuilding = true;
           63|         inherit buildCommand name;
             |                 ^
           64|         passAsFile = [ "buildCommand" ]

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'aarch64-darwin' missing
       at /nix/store/gkcsfrj88x6cbrx2kpkxgsbq5k63fpaj-source/flake.nix:173:19:
          172|                 cp -R --no-preserve=mode,ownership ${
          173|                   released-nixpkgs-stable.htmlDocs.nixosManual.${system}
             |                   ^
          174|                 }/share/doc/nixos $nixos_dir/stable
```
