### PR TITLE
rename newsletter link and move it down

### DIFF
--- a/core/src/content/menus/footer.yaml
+++ b/core/src/content/menus/footer.yaml
@@ -31,10 +31,10 @@ sections:
     items:
       - name: Blog
         link: /blog/
-      - name: Newsletter
-        link: https://weekly.nixos.org/
       - name: Research & Publications
         link: /research
+      - name: NixOS Weekly (Archive)
+        link: https://weekly.nixos.org/
 social:
   - name: Mastodon
     link: https://chaos.social/@nixos_org


### PR DESCRIPTION
This PR renames the NixOS Newsletter link to better help to avoid confusion about its state and how we are handling it currently. This is the result of the discussion in [a previous meeting](https://discourse.nixos.org/t/2025-03-24-marketing-team-minutes/62125).