### PR TITLE
Update board responsibilities to match the constitution

### DIFF
--- a/core/src/content/teams/01_foundation-board.mdx
+++ b/core/src/content/teams/01_foundation-board.mdx
@@ -28,26 +28,26 @@ contact:
     href: https://github.com/orgs/NixOS/projects/28
 ---
 
-Responsible for providing operational and organizational support to the NixOS project and community.
-
-## Responsibilities
+The board is a partner with the Nix Steering Committee (SC) in leadership and is primarily focused on corporate and general external relationships, fiscals/financials, legals and partnerships.
 
 In particular, its responsibilities are to:
 
-- Handle the administrative, legal, and financial tasks of the foundation
-- Serve as an interface between the community and the corporate/governmental world:
-  - Handle sponsoring and donations
-  - Encourage contributions by individuals and organisations alike
-  - Balance the interests of volunteers, commercial actors, and public institutions
+- Own and handle the administrative and legal
+  - Serve as an interface between the community and the corporate/governmental/financial world
+  - Manage trademarks
+- Handle external relationships, partnerships, and donations
+  - Work with the SC to establish foundation policies that balance the interests of volunteers, commercial actors, and public institutions, while staying within legal and administrative feasibility constraints. Both the SC and the board need to approve such policies. This includes sponsorship eligibility and trademark policies.
   - Build and maintain beneficial and collaborative relationships
-- Provide a framework for teams to self-organise:
-  - Hand out the credentials and permissions required for the teams' work
-- Fund community events and efforts
-- Unblock things that would be stuck otherwise, and serve as:
-  - Arbiter in case of conflicts
-  - Backup for critical tasks when needed
+  - Maintain and support grants/grant providers
+- Provide a framework for the community to self-organise:
+  - Handle payments for tooling, meetups, and infrastructure
+  - Manage credentials and permissions
+  - Review and approve constitution changes affecting the board's authority, responsibilities, or appointment procedures.
+- Own and be responsible for financials
+  - Provide fiscal planning and funding for community events and efforts
+  - Decide how much funding is available for each broadly scoped type of events and efforts, while the SC decides the priorities within these scopes and limits of the allocated funds
 
-The board is not responsible for technical leadership, decisions, or direction.
+See the [constitution](https://github.com/NixOS/org/blob/main/doc/constitution.md) for more information on leadership.
 
 ## Links
 


### PR DESCRIPTION
The [version from the constitution](https://github.com/NixOS/org/blob/main/doc/constitution.md#nixos-foundation-board) is the latest revision, so should also be used for the website. Ping @NixOS/foundation 