### PR TITLE
Explain NixOS on the landing page

### DIFF
--- a/core/src/pages/index.astro
+++ b/core/src/pages/index.astro
@@ -45,42 +45,52 @@ posts
       </Banner>
     )
   }
-  <div class="bg-nix-blue inline-svg-hero bg-cover bg-left bg-no-repeat">
-    <Container
-      class="grid grid-cols-1 gap-8 py-16 text-white lg:grid-cols-2 lg:py-24"
-    >
-      <div class="mx-0 my-auto flex flex-col gap-4">
+  <div
+    class="bg-nix-blue inline-svg-hero bg-cover bg-left bg-no-repeat text-white"
+  >
+    <Container class="pt-16">
+      <div class="mx-0 my-auto w-full gap-4">
         <h1 class="font-heading text-5xl leading-none font-bold">
-          Declarative builds<br class="hidden md:inline-block" /> and deployments.
+          Build reproducible development environments, simplify your
+          deployments!
         </h1>
+      </div>
+    </Container>
+
+    <Container class="grid grid-cols-1 gap-8 py-16 lg:grid-cols-2 lg:py-24">
+      <div class="mx-0 my-auto flex flex-col gap-4">
+        <h2 class="font-heading text-5xl leading-none font-bold">Nix</h2>
         <p class="text-lg leading-7 font-extralight">
-          Nix is a tool that takes a unique approach to package management and
-          system configuration. Learn how to make reproducible, declarative and
-          reliable systems.
+          The stand-alone package manager that ensures reproducible builds and
+          makes sure that everything that runs on one machine will also work on
+          another.
         </p>
         <div
           class="flex flex-col justify-center gap-4 text-center md:flex-row lg:justify-start"
         >
           <Button href="/download" color="green" size="lg">Download</Button>
-          <Button href="/learn" color="lightblue" size="lg">Get started</Button>
+          <Button
+            href="https://nix.dev/tutorials/first-steps/"
+            color="lightblue"
+            size="lg">Get started</Button
+          >
         </div>
       </div>
-      <div
-        class="min-h-[300px] rounded-3xl border-[1rem] border-white bg-[#121314] drop-shadow-md"
-      >
-        <Asciinema
-          src="/demos/cover.cast"
-          settings={{
-            cols: 84,
-            poster: 'npt:0:01:22',
-            markers: [
-              [11.5, 'Ad-Hoc development environments'],
-              [41.5, 'Declarative development environments'],
-              [85.0, 'Build docker image with Nix'],
-              [122.0, 'Build minimal docker image with Nix'],
-            ],
-          }}
-        />
+      <div class="mx-0 my-auto flex flex-col gap-4">
+        <h2 class="font-heading text-5xl leading-none font-bold">NixOS</h2>
+        <p class="text-lg leading-7 font-extralight">
+          Run your favourite webservice in 5 minutes: NixOS is a Linux
+          distrubition built on Nix and adds a powerful module system that
+          enables running your favourite application in no time.
+        </p>
+        <div
+          class="flex flex-col justify-center gap-4 text-center md:flex-row lg:justify-start"
+        >
+          <Button href="/download#nixos-iso" color="green" size="lg"
+            >Download</Button
+          >
+          <Button href="/learn" color="lightblue" size="lg">Get started</Button>
+        </div>
       </div>
     </Container>
   </div>

--- a/core/src/pages/learn.astro
+++ b/core/src/pages/learn.astro
@@ -59,16 +59,32 @@ const learningResources = [
 <Layout title="Learn Nix | Nix & NixOS">
   <PageHeader text="Learn" />
   <Container class="grid gap-4 py-16 md:grid-cols-3">
-    {
-      learningFeatures.map((feature) => (
-        <div class="border-0.5 border-nix-blue-darker flex flex-col justify-center gap-8 rounded-2xl p-8">
-          <InlineSVG src={feature.imgUrl} class="h-28" />
-          <Button size="lg-full" color={feature.color} href={feature.url}>
-            {feature.title}
-          </Button>
-        </div>
-      ))
-    }
+    <div>
+      <h3 class="font-heading mb-4 text-2xl font-extrabold">Nix</h3>
+      <div>
+        Nix is a stand-alone package manager that enables Reproducibility,
+        installs packages in isolation to enable developer environments without
+        affecting system-wide configurations and is therefore rollback-friendly.
+        Interested? Take your <a href="https://nix.dev/tutorials/first-steps/">
+          here</a
+        >
+      </div>
+    </div>
+    <div>
+      <h3 class="font-heading mb-4 text-2xl font-extrabold">NixOS</h3>
+      <div>
+        NixOS is a Linux operating system, based on Nix. It has a powerful
+        declarative module system, allows for simple roll-backs and has a robust
+        integration test system, based on VMs.
+      </div>
+    </div>
+    <div>
+      <h3 class="font-heading mb-4 text-2xl font-extrabold">Nixpkgs</h3>
+      <div>
+        Nixpkgs is the package repository that feeds Nix and NixOS. It is freely
+        available on <a href="https://github.com/nixos/nixpkgs">GitHub</a>.
+      </div>
+    </div>
   </Container>
   <Divider style="slope" mirrorY mirrorX />
   <div class="bg-nix-blue py-8 text-white md:px-8">


### PR DESCRIPTION
This PR adds an explanation of Nix and NixOS to the landing page. It also adds a bit of definition of Nix, NixOS and Nixpkgs to the `/learn` page.
Both changes were previewed and discussed in #1648.