### PR TITLE
teams/xen: sync with Nixpkgs' team list; minor improvements.

### DIFF
--- a/core/src/content/teams/14_xen.mdx
+++ b/core/src/content/teams/14_xen.mdx
@@ -14,6 +14,10 @@ members:
     discourse:
     github: CertainLach
     title: Maintainer
+  - name: Rane
+    discourse:
+    github: digitalrane
+    title: Maintainer
 contact:
   - name: Discourse
     href: https://discourse.nixos.org/t/nixos-xen-project-reviving-the-xen-project-hypervisor-on-nixpkgs/52768

--- a/core/src/content/teams/14_xen.mdx
+++ b/core/src/content/teams/14_xen.mdx
@@ -39,4 +39,4 @@ For any issues, comments and enhancements for the Xen packages, please notify th
 - Packaging and testing all `dom0` and `domU` tools.
 - Writing documentation for using the Xen Hypervisor on NixOS.
 - Implementing the corresponding NixOS module.
-- Assuring the security of the Xen Project Hypervisor by rapidly responding to Xen Security Advisories.
+- Assuring the security of the Xen Project Hypervisor by rapidly responding to [Xen Security Advisories](https://xenproject.org/about/security-policy/).


### PR DESCRIPTION
- Adds back @digitalrane, as noted in https://github.com/NixOS/nixpkgs/pull/393306.
- Adds a link to the Xen Security Policy if anyone looking at the team page is interested in learning more about how Xen (and therefore the maintenance team) handles security.