### PR TITLE
learn: clarify that we link to *the* official wiki

### DIFF
--- a/core/src/pages/learn.astro
+++ b/core/src/pages/learn.astro
@@ -42,7 +42,8 @@ const learningResources = [
   },
   {
     title: 'NixOS Wiki',
-    description: 'A user-maintained wiki for Nix and NixOS',
+    description:
+      'The official wiki for Nix and NixOS (wiki.nixos.org); user contributions welcome!',
     url: 'https://wiki.nixos.org/',
     buttonText: 'Check the wiki',
   },


### PR DESCRIPTION
The previous wording was unnecessarily imprecise:
“a wiki” instead of “the wiki”, “user-maintained”, no mention of “official”.

The new wording keeps the connotation of welcoming user contributions (and makes that more explicit), but also makes it clear that this is the official one.

(Created as part of #ZurichZHF)