### PR TITLE
NGI@Nix: update team's infos

### DIFF
--- a/core/src/content/teams/15_ngi.mdx
+++ b/core/src/content/teams/15_ngi.mdx
@@ -71,9 +71,8 @@ These are the people we work for and with:
   - [NGI Zero Discourse category](https://discourse.nixos.org/c/dev/ngi-zero/45)
   - [Reports on past Summers of Nix](https://github.com/ngi-nix/summer-of-nix?#annual-reports)
 - If you’re a current or past NGI Zero grantee: Contact us for free Nix training, pair programming, or support with getting your software to NixOS.
-- If you want to get into professional open source software development: Become a part-time or full-time trainee during Summer of Nix 2025 — [applications open in March 2025](https://github.com/ngi-nix/summer-of-nix?#applications).
 
-For questions or comments, please [contact the team](https://github.com/ngi-nix/summer-of-nix#contact).
+For questions or comments, please [contact the team](https://github.com/ngi-nix/summer-of-nix#contact) or join our [office hours](https://jitsi.lassul.us/ngi-nix-office-hours) on Jitsi every [Tuesday and Thursday from 13:00 to 14:00 UTC](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com).
 
 ## Links
 

--- a/core/src/content/teams/15_ngi.mdx
+++ b/core/src/content/teams/15_ngi.mdx
@@ -72,7 +72,7 @@ These are the people we work for and with:
   - [Reports on past Summers of Nix](https://github.com/ngi-nix/summer-of-nix?#annual-reports)
 - If you’re a current or past NGI Zero grantee: Contact us for free Nix training, pair programming, or support with getting your software to NixOS.
 
-For questions or comments, please [contact the team](https://github.com/ngi-nix/summer-of-nix#contact) or join our [office hours](https://jitsi.lassul.us/ngi-nix-office-hours) on Jitsi every [Tuesday and Thursday from 13:00 to 14:00 UTC](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com).
+For questions or comments, please [contact the team](https://github.com/ngi-nix/summer-of-nix#contact) or join our [office hours on Jitsi](https://jitsi.lassul.us/ngi-nix-office-hours) every [Tuesday and Thursday from 13:00 to 14:00 UTC](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com).
 
 ## Links
 


### PR DESCRIPTION
- Remove offer to apply: Application phase for 2025 has ended.
- Add office hours information.
- Closes ngi-nix/summer-of-nix#148.