### PR TITLE
NixOS Foundation board: Update event funding limits

### DIFF
--- a/core/src/pages/community/event-funding.mdx
+++ b/core/src/pages/community/event-funding.mdx
@@ -25,7 +25,7 @@ If you are planning an event that doesn't look like any of these, but you think 
 
 # Budget
 
-We can spare up to €500 for a meetup and €2000 for a sprint. But we're flexible, so exceptions are possible.
+We can spare up to €200 for a meetup and €800 for a sprint. But we're flexible, so exceptions are possible.
 
 # When should I apply?
 


### PR DESCRIPTION
While the new @NixOS/foundation board is evaluating the financials and prioritisation of funding, we need to be a bit more conservative with event funding.

Note that event funding requests submitted in the past are unaffected.

This change was agreed-upon by all @NixOS/foundation board members.