### PR TITLE
Clarify team membership on moderation page

### DIFF
--- a/core/src/components/pages/community/teams/MembersDisplay.astro
+++ b/core/src/components/pages/community/teams/MembersDisplay.astro
@@ -16,7 +16,12 @@ const titleClasses = `text-3xl font-heading font-bold text-nix-blue`;
   ]}
 >
   <h2 class={titleClasses}>{title}</h2>
-  <ul class="mt-2 font-light">
+  {
+    Astro.props.paragraph && (
+      <p class="mt-2 inline text-gray-700">{Astro.props.paragraph}</p>
+    )
+  }
+  <ul class="mt-2 pt-1 font-light">
     {
       members.map((member) => (
         <li class="border-b-nix-blue-light-hover flex flex-col border-b-1 pt-2 pb-2 first:pt-0 last:border-b-0 last:pb-0">

--- a/core/src/content/teams/08_moderation.mdx
+++ b/core/src/content/teams/08_moderation.mdx
@@ -14,8 +14,18 @@ members:
   - name: '0x4A6F'
     discourse: '0x4A6F'
     title:
+  - name: K900
+    discourse: K900
+    title:
+  - name: Aleksana
+    discourse: Aleksanaa
+    title:
+  - name: arianvp
+    discourse: arianvp
+    title:
 subteams:
   - name: Matrix
+    paragraph: Designated moderators
     members:
       - name: K900
         discourse: K900
@@ -24,6 +34,7 @@ subteams:
         discourse: Aleksanaa
         title: zh-cn moderator
   - name: GitHub
+    paragraph: Designated moderators
     members:
       - name: arianvp
         discourse: arianvp
@@ -61,3 +72,6 @@ Matrix channel.
 
 The project team is obligated to maintain confidentiality with regard to the
 reporter of an incident.
+
+Designated platform moderators are usually in charge, but authority may be
+delegated to one or more members of the broader team.

--- a/core/src/pages/community/teams/[...slug].astro
+++ b/core/src/pages/community/teams/[...slug].astro
@@ -37,6 +37,7 @@ const { Content } = await render(entry);
               <MembersDisplay
                 key={subteam.name}
                 title={subteam.name}
+                paragraph={subteam.paragraph}
                 class="mb-4"
                 members={subteam.members}
                 isSubteam


### PR DESCRIPTION
- List all the members in the Members panel on the right hand side
- Clarify the role of the "subteams" - as they're called in the code

I hope my phrasing does it justice. Feel free to make suggestions @Lassulus and other team members.