### PR TITLE
add socal nug + link to nix.ug

### DIFF
--- a/core/src/content/community/meetups.yaml
+++ b/core/src/content/community/meetups.yaml
@@ -5,6 +5,8 @@ america:
     location: Reston (Virginia)
   - href: https://bayareanixos.com/
     location: San Francisco (California)
+  - href: https://socal-nug.com/
+    location: Los Angeles & San Diego (California)
 europe:
   - href: http://www.meetup.com/Berlin-NixOS-Meetup/
     location: Berlin (Germany)

--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -393,6 +393,7 @@ import nixosFoundationLogo from '../assets/image/nixos-foundation-logo.svg';
   <Divider />
   <Container>
     <h2 class="font-heading text-nix-blue mt-8 text-4xl font-bold">Meetups</h2>
+    <a href="https://nix.ug/">Discover more Nix Meetups and User Groups!</a>
     <div
       class="mt-4 grid auto-cols-fr bg-[url(/images/world-map.svg)] bg-contain bg-no-repeat text-center text-lg font-extralight md:grid-flow-col"
     >

--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -393,11 +393,9 @@ import nixosFoundationLogo from '../assets/image/nixos-foundation-logo.svg';
   <Divider />
   <Container>
     <h2 class="font-heading text-nix-blue mt-8 text-4xl font-bold">Meetups</h2>
-    <p class="mt-2 mb-4 text-l font-bold text-nix-blue">
+    <p class="text-l text-nix-blue mt-2 mb-4 font-bold">
       Discover a comprehensive list of
-      <a class="text-nix-blue" href="https://nix.ug/">
-        Nix User Groups
-      </a>
+      <a class="text-nix-blue" href="https://nix.ug/"> Nix User Groups </a>
     </p>
     <div
       class="mt-4 grid auto-cols-fr bg-[url(/images/world-map.svg)] bg-contain bg-no-repeat text-center text-lg font-extralight md:grid-flow-col"

--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -393,7 +393,10 @@ import nixosFoundationLogo from '../assets/image/nixos-foundation-logo.svg';
   <Divider />
   <Container>
     <h2 class="font-heading text-nix-blue mt-8 text-4xl font-bold">Meetups</h2>
-    <a href="https://nix.ug/">Discover more Nix Meetups and User Groups!</a>
+    <p class="mt-2 mb-4 text-l font-bold text-nix-blue">
+      Discover a comprehensive list of
+      <a class="text-nix-blue" href="https://nix.ug/">Nix User Groups</a>
+    </p>
     <div
       class="mt-4 grid auto-cols-fr bg-[url(/images/world-map.svg)] bg-contain bg-no-repeat text-center text-lg font-extralight md:grid-flow-col"
     >

--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -395,7 +395,9 @@ import nixosFoundationLogo from '../assets/image/nixos-foundation-logo.svg';
     <h2 class="font-heading text-nix-blue mt-8 text-4xl font-bold">Meetups</h2>
     <p class="mt-2 mb-4 text-l font-bold text-nix-blue">
       Discover a comprehensive list of
-      <a class="text-nix-blue" href="https://nix.ug/">Nix User Groups</a>
+      <a class="text-nix-blue" href="https://nix.ug/">
+        Nix User Groups
+      </a>
     </p>
     <div
       class="mt-4 grid auto-cols-fr bg-[url(/images/world-map.svg)] bg-contain bg-no-repeat text-center text-lg font-extralight md:grid-flow-col"


### PR DESCRIPTION
1. Add link to Socal NUG homepage in meetups
1. Add link + text to direct people to nix.ug

Preview of changes
<img width="1116" height="662" alt="image" src="https://github.com/user-attachments/assets/3a9325ea-1bde-4006-b02e-d3fbe43ddc91" />
