### PR TITLE
Fix double clicks on banner buttons

### DIFF
--- a/core/src/components/ui/Banner.astro
+++ b/core/src/components/ui/Banner.astro
@@ -14,7 +14,11 @@ import Container from '../layout/Container.astro';
   const clickables = document.querySelectorAll('.clickable');
   clickables.forEach((clickable) => {
     clickable.classList.add('cursor-pointer');
-    clickable.addEventListener('click', () => {
+    clickable.addEventListener('click', (e) => {
+      // Don't interfere when a user clicks on a button
+      if (e.target.matches('a, button') || e.target.closest('a, button')) {
+        return;
+      }
       clickable.querySelector('a, button').click();
     });
   });


### PR DESCRIPTION
When clicking on an <a> element in a banner we open the link twice, once from the <a> and once from JavaScript. This is easily visible currently with the big "Take the Survey" button for the Nix Community Survey banner. I don't know if this solution is the best approach, it seems logical to me but I haven't used astro before.