### PR TITLE
Use #space:nixos.org for linking to the matrix space

### DIFF
--- a/core/src/content/menus/footer.yaml
+++ b/core/src/content/menus/footer.yaml
@@ -20,7 +20,7 @@ sections:
       - name: Forum
         link: https://discourse.nixos.org/
       - name: Matrix Chat
-        link: https://matrix.to/#/#community:nixos.org
+        link: https://matrix.to/#/#space:nixos.org
       - name: Commercial support
         link: /community/commercial-support
   - name: Contribute

--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -100,7 +100,7 @@ const platformsMain = [
       'Our official forum is the right place to get help from other users and discuss the development of the projects. There are also Announcements, Job offers and Events.',
   },
   {
-    href: 'https://matrix.to/#/#community:nixos.org',
+    href: 'https://matrix.to/#/#space:nixos.org',
     name: 'Matrix space',
     iconName: 'simple-icons:matrix',
     description:


### PR DESCRIPTION
This appears to be the preferred name nowadays, and makes the (confusing) distinction between spaces and rooms in Matrix more clear.

https://matrix.to/#/#space:nixos.org