### PR TITLE
Update Determinate Nix link

### DIFF
--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -183,7 +183,7 @@ const widerEcosystem = [
     name: 'Lix',
   },
   {
-    href: 'https://determinate.systems/nix/',
+    href: 'https://docs.determinate.systems/determinate-nix',
     name: 'Determinate Nix',
   },
   {


### PR DESCRIPTION
The current link is to the Determinate Systems website (https://determinate.systems), which is (a) more of a marketing vehicle and (b) not currently in great shape (on that page). The official documentation (https://docs.determinate.systems) is much more relevant to readers of nixos.org.