### PR TITLE
fix: Use correct casing for GitHub

### DIFF
--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -108,10 +108,10 @@ const platformsMain = [
   },
   {
     href: 'https://github.com/NixOS/',
-    name: 'Github',
+    name: 'GitHub',
     iconName: 'simple-icons:github',
     description:
-      'Official organization page on Github, where you can find nix, nixpkgs, and other repositories.',
+      'Official organization page on GitHub, where you can find nix, nixpkgs, and other repositories.',
   },
 ];
 


### PR DESCRIPTION
This commit leaves the casing for blog post titles in the NixOS weekly newletters untouched since those titles refer to posts in the wild that use the incorrect casing.