### PR TITLE
teams(nixpkgs-core): drop K900

### DIFF
--- a/core/src/content/teams/030_nixpkgs-core.mdx
+++ b/core/src/content/teams/030_nixpkgs-core.mdx
@@ -6,8 +6,6 @@ members:
     github: alyssais
   - name: emilazy
     github: emilazy
-  - name: K900
-    github: K900
   - name: wolfgangwalther
     github: wolfgangwalther
 contact:


### PR DESCRIPTION
K900 stepped down from the core team after being elected to the SC.

Ref: https://github.com/NixOS/org/pull/190

cc @NixOS/nixpkgs-core 