### PR TITLE
Update the Steering Committee post the 2025 election cycle

### DIFF
--- a/core/src/content/teams/000_steering-committee.mdx
+++ b/core/src/content/teams/000_steering-committee.mdx
@@ -2,24 +2,27 @@
 name: Steering Committee
 description: Elected body responsible for technical and social community leadership, setting project direction and serving as a final escalation point.
 members:
+  - name: Christina Sørensen
+    github: cafkafk
+    affiliation: Employed by VitVio; term ends 2027
+  - name: Ilya Katsnelson
+    github: K900
+    affiliation: Employed by Avito Tech LLC; term ends 2027
+  - name: Thomas Bereknyei
+    github: tomberek
+    affiliation: Employed by Anduril; term ends 2027
   - name: John Ericson
     github: Ericson2314
     affiliation: Employed by Obsidian Systems; term ends 2026
-  - name: Gabriella Gonzalez
-    github: Gabriella439
-    affiliation: Employed by Mercury; term ends 2025
-  - name: Jan Tojnar
-    github: jtojnar
-    affiliation: Employer has no relation to Nix; term ends 2025
+  - name: Julien Malka
+    github: JulienMalka
+    affiliation: Funded by the Institut Polytechnique de Paris; term ends 2026
+  - name: Philip Taron
+    github: philiptaron
+    affiliation: Employed by Qumulo; term ends 2026
   - name: Robert Hensing
     github: roberth
     affiliation: Owner of Hercules CI; term ends 2026
-  - name: Thomas Bereknyei
-    github: tomberek
-    affiliation: Employed by Anduril; term ends 2025
-  - name: Winter
-    github: winterqt
-    affiliation: Employed by Antithesis; term ends 2025
 contact:
   - name: Email
     href: mailto:steering@nixos.org


### PR DESCRIPTION
Details about names taken from the https://github.com/NixOS/SC-election-2025 site.

For employer, I followed the campaign materials, but with @K900 in particular, do you want to imitate @jtojnar and state "Employer has no relation to Nix"?

The order is sorted by (term length, first name lexicographical). 