### PR TITLE
teams(cuda): drop @samuela from active members, thank him

### DIFF
--- a/core/src/content/teams/100_cuda.mdx
+++ b/core/src/content/teams/100_cuda.mdx
@@ -2,9 +2,6 @@
 name: CUDA Team
 description: Making Nix and NixOS the first choice for users of CUDA-accelerated software.
 members:
-  - name: Samuel A
-    discourse: samuela
-    title: Team creator
   - name: Serge K
     discourse: sergek
     title:
@@ -60,6 +57,10 @@ infrastructure related to our mission. Therefore, if you or your organization:
 Please consider supporting this effort directly or through the NixOS Foundation.
 Reach out via GitHub [@connorbaker](https://github.com/connorbaker), or email
 connorbaker01@gmail.com to get involved.
+
+## Acknowledgments
+
+The team [was founded in 2022](https://discourse.nixos.org/t/announcing-the-nixos-cuda-maintainers-team-and-a-call-for-maintainers/18074/10) by [Samuel Ainsworth](https://samlikes.pizza) ([nixpkgs-upkeep](https://github.com/samuela/nixpkgs-upkeep), nixpkgs jaxlib, &c.)
 
 ## Contact and Information
 


### PR DESCRIPTION
@samuela is no longer an active member of the CUDA team.
This PR thus removes him from the member list on the team page.
It also adds a short paragraph to acknowledge his invaluable past contributions to the team projects!

cc @ConnorBaker @SomeoneSerge
