### PR TITLE
marketing-team: rename webmaster to web lead

### DIFF
--- a/core/src/content/teams/080_marketing.mdx
+++ b/core/src/content/teams/080_marketing.mdx
@@ -7,7 +7,7 @@ members:
     title: Lead & Brand and Design Steward & Surveys and Metrics Coordinator
   - name: Thilo Billerbeck
     discourse: avocadoom
-    title: Webmaster
+    title: Web Lead
   - name: Florian Pester
     discourse: flyfloh
     title: Social Media Liaison


### PR DESCRIPTION
As discussed in the meeting. Web Lead describes my tasks a bit better.