### PR TITLE
docs: avoid bash-specific process substitution in install command

### DIFF
--- a/core/src/content/download/01-nix-linux.mdx
+++ b/core/src/content/download/01-nix-linux.mdx
@@ -9,7 +9,7 @@ platform: linux
 Install Nix via the <span class="font-bold">recommended</span> [multi-user installation](/manual/nix/stable/installation/multi-user):
 
 ```bash prompt
-$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
+$ curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
 
 On Arch Linux, you can alternatively [install Nix through `pacman`](https://wiki.archlinux.org/title/Nix#Installation).
@@ -23,7 +23,7 @@ We recommend the multi-user install if you are on Linux running systemd, with SE
 Install Nix via the [single-user installation](/manual/nix/stable/installation/single-user):
 
 ```bash prompt
-$ curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+$ curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install | sh -s -- --no-daemon
 ```
 
 Above command will perform a single-user installation of Nix, meaning that `nix` is owned by the invoking user. You should run this under your usual user account, not as `root`. The script will invoke `sudo` to create `/nix` if it doesn’t already exist.

--- a/core/src/content/download/01-nix-linux.mdx
+++ b/core/src/content/download/01-nix-linux.mdx
@@ -9,8 +9,12 @@ platform: linux
 Install Nix via the <span class="font-bold">recommended</span> [multi-user installation](/manual/nix/stable/installation/multi-user):
 
 ```bash prompt
-$ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
+
+On Arch Linux, you can alternatively [install Nix through `pacman`](https://wiki.archlinux.org/title/Nix#Installation).
+
+On Fedora, you can [install Nix via `dnf`](https://src.fedoraproject.org/rpms/nix).
 
 We recommend the multi-user install if you are on Linux running systemd, with SELinux disabled and you can authenticate with `sudo`.
 
@@ -19,7 +23,7 @@ We recommend the multi-user install if you are on Linux running systemd, with SE
 Install Nix via the [single-user installation](/manual/nix/stable/installation/single-user):
 
 ```bash prompt
-$ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --no-daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
 ```
 
 Above command will perform a single-user installation of Nix, meaning that `nix` is owned by the invoking user. You should run this under your usual user account, not as `root`. The script will invoke `sudo` to create `/nix` if it doesn’t already exist.

--- a/core/src/content/download/01-nix-linux.mdx
+++ b/core/src/content/download/01-nix-linux.mdx
@@ -12,10 +12,6 @@ Install Nix via the <span class="font-bold">recommended</span> [multi-user insta
 $ curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
 
-On Arch Linux, you can alternatively [install Nix through `pacman`](https://wiki.archlinux.org/title/Nix#Installation).
-
-On Fedora, you can [install Nix via `dnf`](https://src.fedoraproject.org/rpms/nix).
-
 We recommend the multi-user install if you are on Linux running systemd, with SELinux disabled and you can authenticate with `sudo`.
 
 ### Single-user installation

--- a/core/src/content/download/02-nix-macos.mdx
+++ b/core/src/content/download/02-nix-macos.mdx
@@ -20,7 +20,7 @@ Install Nix via the **recommended** [multi-user installation](/manual/nix/stable
 Open a Terminal (by pressing [Cmd] + [Space] and typing `terminal`) and run the following command:
 
 ```bash prompt
-$ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install)
+$ curl -L https://nixos.org/nix/install | sh
 ```
 
 We believe we have ironed out how to cleanly support the read-only root on modern macOS. Please [consult the manual](/manual/nix/stable/installation/installing-binary#macos-installation) on details what the installation script does.

--- a/core/src/content/download/02-nix-macos.mdx
+++ b/core/src/content/download/02-nix-macos.mdx
@@ -20,7 +20,7 @@ Install Nix via the **recommended** [multi-user installation](/manual/nix/stable
 Open a Terminal (by pressing [Cmd] + [Space] and typing `terminal`) and run the following command:
 
 ```bash prompt
-$ curl -L https://nixos.org/nix/install | sh
+$ curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install | sh
 ```
 
 We believe we have ironed out how to cleanly support the read-only root on modern macOS. Please [consult the manual](/manual/nix/stable/installation/installing-binary#macos-installation) on details what the installation script does.

--- a/core/src/content/download/03-nix-wsl2.mdx
+++ b/core/src/content/download/03-nix-wsl2.mdx
@@ -14,7 +14,7 @@ Follow
 to configure it, and then install Nix using:
 
 ```bash prompt
-$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
+$ curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
 
 ### Single-user installation
@@ -22,5 +22,5 @@ $ curl -L https://nixos.org/nix/install | sh -s -- --daemon
 Install Nix via the [single-user installation](/manual/nix/stable/installation/single-user)
 
 ```bash prompt
-$ curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
+$ curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install | sh -s -- --no-daemon
 ```

--- a/core/src/content/download/03-nix-wsl2.mdx
+++ b/core/src/content/download/03-nix-wsl2.mdx
@@ -14,7 +14,7 @@ Follow
 to configure it, and then install Nix using:
 
 ```bash prompt
-$ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
 
 ### Single-user installation
@@ -22,5 +22,5 @@ $ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemo
 Install Nix via the [single-user installation](/manual/nix/stable/installation/single-user)
 
 ```bash prompt
-$ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --no-daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
 ```


### PR DESCRIPTION
The previous install command used process substitution:

```sh
$ sh <(curl --proto '=https' --tlsv1.2 -L https://nixos.org/nix/install) --daemon
```

Process substitution (<(...)) is not supported by all shells and is not part of the [POSIX shell specification](https://pubs.opengroup.org/onlinepubs/9799919799/). This can cause the command to fail for users running the instructions in environments where the default shell does not implement this feature.

To make the command more portable, replace it with the pipe-based form used in the [official nix.dev documentation](https://nix.dev/install-nix):

```bash
$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
```

I believe this will also fixes #1976 .