### PR TITLE
Revert "Add redirect for eaiser navagation for wiki"

### DIFF
--- a/core/src/pages/wiki/[...slug].astro
+++ b/core/src/pages/wiki/[...slug].astro
@@ -1,8 +1,0 @@
----
-export const prerender = false;
-const { slug } = Astro.params;
-return Astro.redirect(
-  `https://wiki.nixos.org/wiki/${slug ?? 'Main_Page'}`,
-  301,
-);
----


### PR DESCRIPTION
Reverting this for now since `slug` routes require a server rendering adapter which we currently do not have, since the site is fully statically generated