### PR TITLE
Bugfix: Headline hash anchors and dynamic tag typing

### DIFF
--- a/core/src/components/ui/typography/Headline.astro
+++ b/core/src/components/ui/typography/Headline.astro
@@ -36,6 +36,7 @@ const Anchor = anchor && id ? 'a' : Fragment;
   id={id}
   class:list={[
     'font-heading relative leading-tight font-bold',
+    anchor && id && 'scroll-mt-24',
     level === 1 && 'text-4xl md:text-5xl',
     level === 2 && 'text-4xl',
     level === 3 && 'text-2xl',

--- a/core/src/components/ui/typography/Headline.astro
+++ b/core/src/components/ui/typography/Headline.astro
@@ -1,9 +1,12 @@
 ---
 import { Icon } from 'astro-icon/components';
 
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
 interface Props {
-  tag?: string;
-  level: number;
+  tag?: HeadingTag;
+  level: HeadingLevel;
   variant: 'blue' | 'white' | 'sr-only';
   center?: boolean;
   class?: string;

--- a/core/src/components/ui/typography/Headline.astro
+++ b/core/src/components/ui/typography/Headline.astro
@@ -33,6 +33,7 @@ const Anchor = anchor && id ? 'a' : Fragment;
 ---
 
 <Tag
+  id={id}
   class:list={[
     'font-heading relative leading-tight font-bold',
     level === 1 && 'text-4xl md:text-5xl',


### PR DESCRIPTION
Fixes the `Headline` component so generated hash anchors scroll to the expected heading and cleans up the TypeScript typing for dynamic heading tags.