### PR TITLE
research: add publication on quantum chemistry software

### DIFF
--- a/core/src/pages/research.astro
+++ b/core/src/pages/research.astro
@@ -469,6 +469,30 @@ const papers: ReadonlyArray<Paper> = [
     },
   },
   {
+    title:
+      'Sustainable packaging of quantum chemistry software with the Nix package manager',
+    authors: [
+      {
+        name: 'Markus Kowalewski',
+        orcidUrl: 'https://orcid.org/0000-0002-2288-2548',
+      },
+      {
+        name: 'Phillip Seeber',
+        orcidUrl: 'https://orcid.org/0000-0002-4968-7726',
+      },
+    ],
+    year: 2022,
+    abstract:
+      'The installation of quantum chemistry software packages is commonly done manually and can be a time-consuming and complicated process. An update of the underlying Linux system requires a reinstallation in many cases and can quietly break software installed on the system. In this paper, we present an approach that allows for an easy installation of quantum chemistry software packages, which is also independent of operating system updates. The use of the Nix package manager allows building software in a reproducible manner, which allows for a reconstruction of the software for later reproduction of scientific results. The build recipes that are provided can be readily used by anyone to avoid complex installation procedures.',
+    doiOrPublisherUrl: '10.1002/qua.26872',
+    publicationInfo: {
+      type: 'journal',
+      journal: 'International Journal of Quantum Chemistry',
+      volume: '122',
+      pages: 'e26872',
+    },
+  },
+  {
     title: 'Build systems à la carte: Theory and practice',
     authors: [
       {


### PR DESCRIPTION
Add our 2022 Nix paper on quantum chemistry software to the research page.