### PR TITLE
community: replace Reston meetup with Herndon (dmvnix.org)

### DIFF
--- a/core/src/content/community/meetups.yaml
+++ b/core/src/content/community/meetups.yaml
@@ -1,8 +1,8 @@
 america:
   - href: https://www.meetup.com/New-York-Nix-Users-Group/
     location: New York (New York)
-  - href: https://www.meetup.com/Nova-Nix-NixOS-NixOps-Meetup/
-    location: Reston (Virginia)
+  - href: https://dmvnix.org/
+    location: Herndon (Virginia)
   - href: https://bayareanixos.com/
     location: San Francisco (California)
   - href: https://socal-nug.com/


### PR DESCRIPTION
The Nova Nix/NixOS/NixOps meetup based in Reston is no longer the active local group; the DC/Maryland/Virginia community now meets as DMV Nix in Herndon. Update the entry to point at dmvnix.org.