### PR TITLE
stories: update old wiki links (nixos.wiki -> wiki.nixos.org)

### DIFF
--- a/core/src/content/blog/stories/PerlDivingWithNix.md
+++ b/core/src/content/blog/stories/PerlDivingWithNix.md
@@ -511,4 +511,4 @@ This means that somehow we need to make the compiler aware of the correct paths 
 This is where `NIX_LDFLAGS` (and its partner in compile `NIX_CFLAGS_COMPILE`) come in.
 The ALL CAPS should give you a clue that they are _environment variables_ which are used to furnish the compiler (by way of command line arguments) with these correct paths.
 This is all done using shell scripts that wrap around the actual compiler.
-For more information see the [C section](https://nixos.wiki/wiki/C) on the Nixos Wiki.
+For more information see the [C section](https://wiki.nixos.org/wiki/C) on the Nixos Wiki.

--- a/core/src/content/blog/stories/deploying-simple-jitsi-meet-server.md
+++ b/core/src/content/blog/stories/deploying-simple-jitsi-meet-server.md
@@ -80,7 +80,7 @@ you can skip to [Getting basic Jitsi Meet service running](#getting-basic-jitsi-
 For configuring and deploying it,
 [Nix](https://nixos.org) with flakes support is required to be installed on your local system.
 If you have Nix version 3 or above, everything is already set up.
-Otherwise, you need to [enable it explicitly](https://nixos.wiki/wiki/Flakes#Enable_flakes).
+Otherwise, you need to [enable it explicitly](https://wiki.nixos.org/wiki/Flakes#Setup).
 
 ## Setting up NixOS
 


### PR DESCRIPTION
After comparing the contents of linked sections on the old and the new wikis, i haven't found any loss of information that would somehow harm the `stories` entries in question.

Among the other things, the https://nixos.wiki/wiki/Flakes#Enable_flakes
section no longer exists as linked, so the new wiki link will drop straight into the right section.