### PR TITLE
Add Wiki link to navigation menu

### DIFF
--- a/core/src/content/menus/header.yaml
+++ b/core/src/content/menus/header.yaml
@@ -5,6 +5,8 @@ items:
     link: /download
   - name: Learn
     link: /learn
+  - name: Wiki
+    link: https://wiki.nixos.org/wiki/NixOS_Wiki
   - name: Governance
     link: /governance
   - name: Community


### PR DESCRIPTION
The header menu currently lacks a direct link to the NixOS Wiki.
Users had to navigate imo 2 much to find it.

This adds a Wiki entry to the top nav, linking to https://wiki.nixos.org/wiki/NixOS_Wiki.
The link opens in a new tab since the Wiki has its own navigation.