### PR TITLE
Update foundation contact methods and links

### DIFF
--- a/core/src/content/teams/010_foundation-board.mdx
+++ b/core/src/content/teams/010_foundation-board.mdx
@@ -23,14 +23,12 @@ members:
     title: President/Chair
     affiliation: Founder / Chief Executive Officer of Flox
 contact:
-  - name: Discourse
-    href: https://discourse.nixos.org/c/dev/nixos-foundation/47
-  - name: Matrix
-    href: https://matrix.to/#/#foundation:nixos.org
+  - name: Mail
+    href: mailto:foundation@nixos.org
   - name: GitHub
     href: https://github.com/NixOS/foundation
-  - name: GitHub project board
-    href: https://github.com/orgs/NixOS/projects/28
+  - name: Matrix
+    href: https://matrix.to/#/#foundation:nixos.org
 ---
 
 The board is a partner with the Nix Steering Committee (SC) in leadership and is primarily focused on corporate and general external relationships, fiscals/financials, legals and partnerships.
@@ -63,26 +61,6 @@ import Button from '../../components/ui/Button.astro';
     color="semidarkblue"
     size="sm"
     href="https://discourse.nixos.org/c/dev/nixos-foundation/47"
-    label="Discourse"
-  />
-  <Button
-    color="semidarkblue"
-    size="sm"
-    href="https://matrix.to/#/#foundation:nixos.org"
-    label="Matrix"
-  />
-  <Button
-    color="semidarkblue"
-    size="sm"
-    href="https://github.com/orgs/NixOS/projects/28"
-    nonPublic
-    label="GitHub Project board"
-  />
-  <Button
-    color="semidarkblue"
-    size="sm"
-    href="https://github.com/orgs/NixOS/teams/foundation"
-    nonPublic
-    label="GitHub Team page"
+    label="Announcements"
   />
 </div>


### PR DESCRIPTION
Project board is internal and not used atm anyways, can be removed

Discourse is not really a contact method for the board in itself, emphasize it as how announcements are made however