### PR TITLE
Fix prod deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -52,7 +52,7 @@ jobs:
       - name: 'Build'
         run: |
           now=$(date +%s)
-          if [[ "$(date +%s --date="1 Jun")" <= "$now" && "$now" < "$(date +%s --date="15 July")" ]]; then
+          if [[ "$(date +%s --date="1 Jun")" < "$now" && "$now" < "$(date +%s --date="15 July")" ]]; then
             export THEME=pride
           else
             export THEME=default


### PR DESCRIPTION
Bash doesn't have `<=` apparently..?!

Follow-up to #2037, which broke the deploy: https://github.com/NixOS/nixos-homepage/actions/runs/26770861864/job/78909651322