### PR TITLE
chore: bump package count

### DIFF
--- a/core/src/pages/index.astro
+++ b/core/src/pages/index.astro
@@ -146,7 +146,7 @@ posts
         class="flex w-full flex-col items-center justify-center gap-4 pt-8 pb-8"
       >
         <Headline level={2} center variant="blue" class="text-4xl">
-          Choose from over 120 000 Packages
+          Choose from over 140 000 Packages
         </Headline>
         <Paragraph size="xl" class="pb-3 md:w-5/8" center>
           The Nix Packages collection (<a


### PR DESCRIPTION
We are providing `144159` packages (`144078` on Yarara)!

See:
 - https://github.com/NixOS/nixos-search/pull/1305
 - https://github.com/NixOS/nixpkgs/pull/527773