### PR TITLE
security: retire ris

### DIFF
--- a/core/src/content/teams/040_security.mdx
+++ b/core/src/content/teams/040_security.mdx
@@ -5,9 +5,6 @@ members:
   - name: Martin Weinelt
     discourse: hexa
     title:
-  - name: Robert Scott
-    discourse: ris
-    title:
   - name: Thomas Gerbet
     discourse: tgerbet
     title:
@@ -45,10 +42,6 @@ To privately report a security issue with NixOS, Nix, and its ecosystem, please 
 - **Martin Weinelt**<br/>
   Email: [hexa@darmstadt.ccc.de](mailto:hexa@darmstadt.ccc.de)<br class="mb-1"/>
   GPG Fingerprint: [`F7D6 7CFB F2CA 32F1 641A 03DB 0D9F 7008 4786 0BC5`](https://keys.openpgp.org/vks/v1/by-fingerprint/F7D67CFBF2CA32F1641A03DB0D9F700847860BC5)
-
-- **Robert Scott**<br/>
-  Email: [secure@humanleg.org.uk](mailto:secure@humanleg.org.uk)<br class="mb-1"/>
-  GPG Fingerprint: [`8868 8AE4 8AE6 3195 BCF5 F732 3A7B 7B7A 2611 CE25`](https://keys.openpgp.org/vks/v1/by-fingerprint/88688AE48AE63195BCF5F7323A7B7B7A2611CE25)
 
 - **Thomas Gerbet**<br/>
   Email: [thomas@gerbet.me](mailto:thomas@gerbet.me)<br class="mb-1"/>


### PR DESCRIPTION
He is stepping back due to other commitments.

https://github.com/orgs/NixOS/teams/security/members

cc @risicle 