### PR TITLE
fix: correct Nixpkgs link on homepage

### DIFF
--- a/core/src/pages/index.astro
+++ b/core/src/pages/index.astro
@@ -151,7 +151,7 @@ posts
         <Paragraph size="xl" class="pb-3 md:w-5/8" center>
           The Nix Packages collection (<a
             class="text-secondary-afghani-blue! font-bold"
-            href="#">Nixpkgs</a
+            href="https://github.com/nixos/nixpkgs">Nixpkgs</a
           >) offers a large selection of packages for the Nix package manager.
         </Paragraph>
         <NixosSearchInput collection="packages" withSubmit />


### PR DESCRIPTION
Currently the  `<a>` on the `Nixpkgs` in the homepage links to itself. I don't think that's the intended behavior, but if it is, feel free to close this PR.