### PR TITLE
Serve the NixOS community survey site under /surveys

### DIFF
--- a/core/devserver.mjs
+++ b/core/devserver.mjs
@@ -27,6 +27,7 @@ const devServer = await dev({
 app.use('/manual', express.static(process.env.PATH_MANUAL));
 app.use('/guides/nix-pills', express.static(process.env.PATH_PILLS));
 app.use('/demos', express.static(process.env.PATH_DEMOS));
+app.use('/surveys', express.static(process.env.PATH_SURVEYS));
 app.use(devServer.handle);
 
 app.listen(devServer.address.port + 1, () => {

--- a/core/src/content/menus/footer.yaml
+++ b/core/src/content/menus/footer.yaml
@@ -13,6 +13,8 @@ sections:
         link: /community/teams/security
       - name: Branding
         link: /branding
+      - name: Surveys
+        link: /surveys
       - name: Summer of Nix
         link: https://github.com/ngi-nix/summer-of-nix
       - name: Devices

--- a/flake.lock
+++ b/flake.lock
@@ -463,15 +463,16 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1782491402,
-        "narHash": "sha256-j0q+WaMg2gvIipw47MtSX1GQ7IbzGDLCXMY3K4TvpZk=",
+        "lastModified": 1782925076,
+        "narHash": "sha256-YF1jFZ97JNX11asxI9cW39iLBX4F6JM+SWTdGbNGBbE=",
         "owner": "NixOS",
         "repo": "surveys",
-        "rev": "638f255851a937c7ceba15b69fdf0e74b634d931",
+        "rev": "3aa45ec2a8c7a3d3c41b659ff6d6d1445d07e58f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "djacu/base-aware-internal-links",
         "repo": "surveys",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -264,6 +264,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1780195591,
+        "narHash": "sha256-/LAL+E75c0ioCHxyVFGwzXorfuHzToKgqPUCRq4RTIY=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "49d924421d7c3175edc499fdc738bd70d69d97d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -334,6 +349,22 @@
       "original": {
         "type": "tarball",
         "url": "https://channels.nixos.org/nixos-26.05/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1770115704,
+        "narHash": "sha256-KHFT9UWOF2yRPlAnSXQJh6uVcgNcWlFqqiAZ7OVlHNc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e6eae2ee2110f3d31110d5c222cd395303343b08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "released-nix-stable": {
@@ -422,7 +453,27 @@
         "released-nix-unstable": "released-nix-unstable",
         "released-nixpkgs-stable": "released-nixpkgs-stable",
         "released-nixpkgs-unstable": "released-nixpkgs-unstable",
+        "surveys": "surveys",
         "systems": "systems"
+      }
+    },
+    "surveys": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1782491402,
+        "narHash": "sha256-j0q+WaMg2gvIipw47MtSX1GQ7IbzGDLCXMY3K4TvpZk=",
+        "owner": "NixOS",
+        "repo": "surveys",
+        "rev": "638f255851a937c7ceba15b69fdf0e74b634d931",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "surveys",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -463,16 +463,15 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1782925076,
+        "lastModified": 1783264720,
         "narHash": "sha256-YF1jFZ97JNX11asxI9cW39iLBX4F6JM+SWTdGbNGBbE=",
         "owner": "NixOS",
         "repo": "surveys",
-        "rev": "3aa45ec2a8c7a3d3c41b659ff6d6d1445d07e58f",
+        "rev": "78c18f52957fe46b9f18a33b8db92aa601d3ab9b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "djacu/base-aware-internal-links",
         "repo": "surveys",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -195,6 +195,10 @@ rec {
 
             npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
+            buildPhase = ''
+              npm run build -- --base /surveys
+            '';
+
             installPhase = ''
               mkdir -p $out
               cp -r ./dist/* $out

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@ rec {
     released-nix-stable.url = "github:nixos/nix/latest-release";
 
     # survey
-    surveys.url = "github:NixOS/surveys/djacu/base-aware-internal-links";
+    surveys.url = "github:NixOS/surveys";
 
     nix-pills.url = "github:NixOS/nix-pills";
     nix-pills.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@ rec {
     released-nix-stable.url = "github:nixos/nix/latest-release";
 
     # survey
-    surveys.url = "github:NixOS/surveys";
+    surveys.url = "github:NixOS/surveys/djacu/base-aware-internal-links";
 
     nix-pills.url = "github:NixOS/nix-pills";
     nix-pills.flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@ rec {
     released-nixpkgs-stable.url = "nixpkgs/nixos-26.05";
     released-nix-unstable.url = "github:nixos/nix/master";
     released-nix-stable.url = "github:nixos/nix/latest-release";
+
+    # survey
+    surveys.url = "github:NixOS/surveys";
+
     nix-pills.url = "github:NixOS/nix-pills";
     nix-pills.flake = false;
   };
@@ -38,6 +42,7 @@ rec {
       released-nix-unstable,
       released-nix-stable,
       nix-pills,
+      surveys,
       systems,
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -178,6 +183,24 @@ rec {
             cp ${nixPills.epub}/share/doc/nix-pills/nix-pills.epub $out/nix-pills.epub
           '';
 
+          surveySite = pkgs.buildNpmPackage {
+            pname = "nixos-surveys";
+            version = "0.0.0";
+
+            src = "${surveys}/lib/site";
+
+            npmDeps = pkgs.importNpmLock {
+              npmRoot = "${surveys}/lib/site";
+            };
+
+            npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+
+            installPhase = ''
+              mkdir -p $out
+              cp -r ./dist/* $out
+            '';
+          };
+
           demos =
             pkgs.runCommand "demos"
               {
@@ -249,11 +272,14 @@ rec {
               mkdir -p $out/manual
               mkdir -p $out/guides/nix-pills
               mkdir -p $out/demos
+              mkdir -p $out/surveys
+
 
               cp -r ${core}/* $out
               cp -r ${manuals}/* $out/manual
               cp -r ${pills}/* $out/guides/nix-pills
               cp -r ${demos}/* $out/demos
+              cp -r ${surveySite}/* $out/surveys
             '';
           };
 
@@ -305,6 +331,7 @@ rec {
               export PATH_MANUAL="${manuals}"
               export PATH_PILLS="${pills}"
               export PATH_DEMOS="${demos}"
+              export PATH_SURVEYS="${surveySite}"
 
               if [ ! -d node_modules ]; then
                 ${nodejs_current}/bin/npm install --workspaces --include-workspace-root

--- a/flake.nix
+++ b/flake.nix
@@ -195,8 +195,17 @@ rec {
 
             npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
+            preBuild = ''
+              mkdir -p src/content/results                                                                   
+              cp ${
+                surveys.legacyPackages.${system}.nixos-surveys-community-2025-data
+              }/results-2025.json src/content/results/results-2025.json
+            '';
+
             buildPhase = ''
+              runHook preBuild
               npm run build -- --base /surveys
+              runHook postBuild
             '';
 
             installPhase = ''


### PR DESCRIPTION
Integrates the [NixOS/surveys](https://github.com/NixOS/surveys) site into the homepage so survey results are served at `/surveys`.