### PR TITLE
Documentation team funding 2026 announcement

### DIFF
--- a/core/src/content/blog/announcements/2026-07-10_docs-funding-2026.md
+++ b/core/src/content/blog/announcements/2026-07-10_docs-funding-2026.md
@@ -1,0 +1,24 @@
+---
+id: docs-funding-2026
+title: Documentation team funding
+date: 2026-07-10T12:00:00.000Z
+category: announcements
+---
+
+tl;dr: There is a renewed effort to improve documentation, head to https://opencollective.com/nixos/projects/nix-documentation or contact <foundation@nixos.org> to chip in with funding!
+
+With the [2023 crowd-funding in documentation funding](https://discourse.nixos.org/t/fundraising-for-the-nix-documentation-project/27009), we've seen some improvements, but a lot more is needed to make significant progress towards improving the overall experience with Nix documentation, including onboarding and discovery. Especially newcomers frequently struggle with our documentation, get frustrated and notice gaps, and have a hard time adopting Nix.
+
+In addition, in the [Nix community survey 2025](https://nixos.org/surveys/community/2025/#foundation) we see that most people want excess funding to be allocated to improving documentation. While the NixOS Foundation doesn't have that much excess funding, @hsjobeki has stepped up to pick up leadership of the [documentation team](https://nixos.org/community/teams/documentation/) with support by @friedow. While they're volunteering their own time to lead the team, they'd like to have access to funding for not just ensuring that stuff gets done, but also maintained over time.
+
+They've collaborated to agree on a [documentation vision](https://github.com/NixOS/nix.dev/blob/master/maintainers/vision.md) ([initial announcement](https://discourse.nixos.org/t/one-portal-for-nixos-documentation-the-docs-team-vision/77818)) to work towards. For that reason, we're asking individuals and companies to donate to the renewed [documentation team OpenCollective](https://opencollective.com/nixos/projects/nix-documentation), so that we can reach the funding goals (more details on OpenCollective):
+
+1. (1.000 €/month) Paid documentation maintainer
+1. (4.000 €) Framework evaluation
+1. (15.000 €) Page splitting in nixos-render-docs
+1. (8.000 €) Continuous deployment & Reduce feedback times
+1. (8.000 €) Navigation & redirects
+
+If a company is interested in providing a significant amount of funding and would like a contract and invoice, please reach out to <foundation@nixos.org>.
+
+Furthermore, if you'd like to support documentation in non-monetary ways, feel free to join the [Matrix channel](https://matrix.to/#/#docs:nixos.org) and/or bi-weekly meetings (see "Nix documentation meeting" in the [NixOS Calendar](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com)), or see where you can help from updates in the [discourse category](https://discourse.nixos.org/c/dev/documentation/25).


### PR DESCRIPTION
Announcement coming from the @NixOS/foundation board in cooperation with the @NixOS/documentation-team :)

@flyfloh: Please also announce this on socials after merged, you can use this blob:

> The NixOS foundation, in collaboration with the Nix documentation team, has opened a renewed funding campaign for improving #nix #nixos documentation, head to https://opencollective.com/nixos/projects/nix-documentation to see the funding goals and chip in, contact <foundation@nixos.org> for a company invoice, or read more in the announcement! <link to page>