### PR TITLE
Make additions to community-support require SC approval

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+core/src/content/community/commercial-support.yaml @NixOS/steering

--- a/core/src/content/community/commercial-support.yaml
+++ b/core/src/content/community/commercial-support.yaml
@@ -1,3 +1,4 @@
+# Additions must be majority-approved by @NixOS/steering
 - href: https://nixcademy.com
   name: Nixcademy
   logo: /images/commercial-support-logos/nixcademy.svg


### PR DESCRIPTION
The @NixOS/foundation board was asked about how new [commercial support page](https://nixos.org/community/commercial-support/) addition request (like #2059 and #1972) should be handled. While the requirements might be tightened more in the future, the board at least agreed that SC approval should be necessary, closely aligning with [their role](https://nixos.org/community/teams/steering-committee/).

@NixOS/steering If that's fine with you too, please majority approve this PR. Note that you might want to review all the existing companies on the [commercial support page](https://nixos.org/community/commercial-support/) first and only approve if you agree with all of them being there. We might need to have a revision to remove the ones you don't agree with being there then.