### PR TITLE
Add Discourse link to docs team funding announcement

### DIFF
--- a/core/src/content/blog/announcements/2026-07-10_docs-funding-2026.md
+++ b/core/src/content/blog/announcements/2026-07-10_docs-funding-2026.md
@@ -22,3 +22,5 @@ They've collaborated to agree on a [documentation vision](https://github.com/Nix
 If a company is interested in providing a significant amount of funding and would like a contract and invoice, please reach out to <foundation@nixos.org>.
 
 Furthermore, if you'd like to support documentation in non-monetary ways, feel free to join the [Matrix channel](https://matrix.to/#/#docs:nixos.org) and/or bi-weekly meetings (see "Nix documentation meeting" in the [NixOS Calendar](https://calendar.google.com/calendar/u/0/embed?src=b9o52fobqjak8oq8lfkhg3t0qg@group.calendar.google.com)), or see where you can help from updates in the [discourse category](https://discourse.nixos.org/c/dev/documentation/25).
+
+You can also read and discuss this announcement [on Discourse](https://discourse.nixos.org/t/documentation-team-funding-2026/78869).


### PR DESCRIPTION
Follow-up to #2070 