### PR TITLE
fix(demo): add missing opening bracket in cover.scenario

### DIFF
--- a/demos/cover.scenario
+++ b/demos/cover.scenario
@@ -91,7 +91,7 @@ $ cat -n redis-minimal.nix
     1  {
     2    pkgs ? import <nixpkgs> { system = "x86_64-linux"; },
     3  }: # nixpkgs package set
-    4  pkgs.redis.override {
+    4  (pkgs.redis.override {
     5    withSystemd = false;  # Build without systemd
     6    tlsSupport = false;  # Build without tls support
     7    useSystemJemalloc = false;  # Dont use system jemalloc


### PR DESCRIPTION
## Description

This PR fixes a small syntax error in the `redis-minimal.nix` demo script inside `cover.scenario` shown on the NixOS homepage. A missing opening bracket on the `pkgs.redis.override` call caused a syntax error when trying to reproduce the demo. 

As a person who was genuinely starting learning nix/nixos, I could say that this fix concerns overall UX of the project, myself being a use-case. When trying to understand the script from the cover page demo I have noticed the mismatch in the amount of opening brackets and closing ones, which led me reproducing the demo to attempt to fix it:

Changing `pkgs.redis.override {` to `(pkgs.redis.override {` corrects this and let nix-build command to be ran. 

## Note and heads up on build failure

While testing this fix locally with the latest `nixpkgs`, I noticed that the `nix-build docker-redis-minimal.nix` step currently fails in the later stages. 

```
ld.bfd: crtbeginT.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a shared object
```

This PR strictly scopes the syntax fix for the landing page demo, but I could create an issue, if needed, upon fixing this syntax error. I would not have enough competence to make claims on the nature of the deeper issue here, but  maintainers might find this _LLM-produced_ analysis relevant, so adding this as a heads up:

```
The derivation forces strict static compilation (`musl-gcc -static`), but modern versions of Redis (e.g., 8.8.0) now build test modules as dynamically linked shared objects (`.so`) by default. Suggestion is to update the demo to use `pkgs.pkgsStatic.redis` or adjust the `makeFlags` to disable building dynamic test modules, so that the demo continues to work end-to-end on newer `nixpkgs` releases.
```