### PR TITLE
content: add NixCon 2026 ticket sales banner

### DIFF
--- a/core/src/content/banners/nixcon-2026-tickets.mdx
+++ b/core/src/content/banners/nixcon-2026-tickets.mdx
@@ -1,0 +1,30 @@
+---
+sitewide:
+  message: 'NixCon 2026 ticket sales open!'
+  link:
+    url: https://tickets.nixcon.org/nixcon-2026/
+    text: 'Ticket-Shop'
+  wrapperClasses: 'bg-[#260D40] text-primary-white'
+---
+
+import Banner from '@/components/ui/Banner.astro';
+
+<Banner
+  wrapperClasses="bg-gradient-to-r from-[#260D40] to-secondary-afghani-blue text-white"
+  class="font-heading flex flex-col items-center justify-between gap-1 text-lg font-bold md:flex-row"
+>
+  <span>
+    <span class="text-2xl font-bold">NixCon 2026 ticket sales open!</span>
+    <span class="text-md">
+      NixCon 2026 in Kraków, Poland, 25–28 September!{' '}
+    </span>
+  </span>
+  <a
+    href="https://tickets.nixcon.org/nixcon-2026/"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="bg-primary-white text-primary-black hover:bg-primary-black mt-1.5 w-full rounded-md px-4 py-3 text-center leading-none font-bold no-underline hover:text-white md:mt-0 md:w-auto"
+  >
+    Get tickets here
+  </a>
+</Banner>

--- a/core/src/content/banners/nixcon-2026-tickets.mdx
+++ b/core/src/content/banners/nixcon-2026-tickets.mdx
@@ -10,8 +10,8 @@ sitewide:
 import Banner from '@/components/ui/Banner.astro';
 
 <Banner
-  wrapperClasses="bg-gradient-to-r from-[#260D40] to-secondary-afghani-blue text-white"
-  class="font-heading flex flex-col items-center justify-between gap-1 text-lg font-bold md:flex-row"
+  wrapperClasses="bg-gradient-to-r from-[#260D40] to-secondary-afghani-blue text-primary-white"
+  class="font-heading flex flex-col items-start justify-between gap-1 text-lg font-bold md:flex-row md:items-center"
 >
   <span>
     <span class="text-2xl font-bold">NixCon 2026 ticket sales open!</span>
@@ -23,7 +23,7 @@ import Banner from '@/components/ui/Banner.astro';
     href="https://tickets.nixcon.org/nixcon-2026/"
     target="_blank"
     rel="noopener noreferrer"
-    class="bg-primary-white text-primary-black hover:bg-primary-black mt-1.5 w-full rounded-md px-4 py-3 text-center leading-none font-bold no-underline hover:text-white md:mt-0 md:w-auto"
+    class="bg-primary-white text-primary-black hover:bg-primary-black hover:text-primary-white mt-1.5 w-full rounded-md px-4 py-3 text-center leading-none font-bold no-underline md:mt-0 md:w-auto"
   >
     Get tickets here
   </a>


### PR DESCRIPTION
Just talked to @Lassulus about NixCon 2026 taking place in two months in Kraków, Poland.

Last times we had a banner to boost ticket sales. Since ticket sales [started some time ago](https://discourse.nixos.org/t/nixcon-2026-ticket-sales-open/77042/1), I phrased it vaguely.

`BANNER` needs to be set to `core/src/content/banners/nixcon-2026-tickets` at GitHub by someone.