### PR TITLE
content: add Bluesky to social links

### DIFF
--- a/core/src/content/menus/footer.yaml
+++ b/core/src/content/menus/footer.yaml
@@ -44,6 +44,8 @@ sections:
       - name: NixOS Weekly (Archive)
         link: https://weekly.nixos.org/
 social:
+  - name: Bluesky
+    link: https://bsky.app/profile/nixos.org
   - name: Mastodon
     link: https://chaos.social/@nixos_org
   - name: X

--- a/core/src/pages/community.astro
+++ b/core/src/pages/community.astro
@@ -126,6 +126,11 @@ const platformsMain = [
 
 const socialMediaMain = [
   {
+    href: 'https://bsky.app/profile/nixos.org',
+    name: 'Bluesky',
+    iconName: 'simple-icons:bluesky',
+  },
+  {
     href: 'https://chaos.social/@nixos_org',
     name: 'Mastodon',
     iconName: 'simple-icons:mastodon',


### PR DESCRIPTION
The NixOS Foundation posts on Bluesky as @nixos.org, but the account isn't linked anywhere on the site. Add it to the two places that list the project's social accounts: the footer's "Connect with us" icon row and the "Social media" section on /community.

The handle is domain-verified against nixos.org, so it can be trusted as the official account. simple-icons ships a `bluesky` icon, so the footer's name-derived icon lookup resolves without further changes.