### PR TITLE
ci: unblock fork PR checkout after actions/checkout v7

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -23,8 +23,6 @@ jobs:
   check:
     name: "Check nixos.org PR"
     runs-on: "ubuntu-latest"
-    # Executes untrusted code from the PR head. Do not add secrets to this job:
-    # the deploy credentials belong to `publish`, which never checks out PR code.
     permissions:
       contents: read
     steps:
@@ -36,9 +34,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           clean: true
-          # Required since actions/checkout v7, which otherwise refuses to check
-          # out fork code under `pull_request_target`. See the note on this job:
-          # the opt-in is only safe while this job stays free of secrets.
+          # TODO: rework ci (or switch systems entirely) to circumvent this
           allow-unsafe-pr-checkout: true
       - name: "Install npm dependencies"
         run: |
@@ -54,8 +50,6 @@ jobs:
     name: "Build nixos.org PR"
     runs-on: "ubuntu-latest"
     needs: check
-    # Executes untrusted code from the PR head. Do not add secrets to this job:
-    # the deploy credentials belong to `publish`, which never checks out PR code.
     permissions:
       contents: read
     steps:
@@ -67,9 +61,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           clean: true
-          # Required since actions/checkout v7, which otherwise refuses to check
-          # out fork code under `pull_request_target`. See the note on this job:
-          # the opt-in is only safe while this job stays free of secrets.
+          # TODO: rework ci (or switch systems entirely) to circumvent this
           allow-unsafe-pr-checkout: true
       - name: "Installing Nix"
         uses: "cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342" # v31.11.0

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -23,6 +23,8 @@ jobs:
   check:
     name: "Check nixos.org PR"
     runs-on: "ubuntu-latest"
+    # Executes untrusted code from the PR head. Do not add secrets to this job:
+    # the deploy credentials belong to `publish`, which never checks out PR code.
     permissions:
       contents: read
     steps:
@@ -34,6 +36,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           clean: true
+          # Required since actions/checkout v7, which otherwise refuses to check
+          # out fork code under `pull_request_target`. See the note on this job:
+          # the opt-in is only safe while this job stays free of secrets.
+          allow-unsafe-pr-checkout: true
       - name: "Install npm dependencies"
         run: |
           npm install --workspaces --include-workspace-root
@@ -48,6 +54,8 @@ jobs:
     name: "Build nixos.org PR"
     runs-on: "ubuntu-latest"
     needs: check
+    # Executes untrusted code from the PR head. Do not add secrets to this job:
+    # the deploy credentials belong to `publish`, which never checks out PR code.
     permissions:
       contents: read
     steps:
@@ -59,6 +67,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           clean: true
+          # Required since actions/checkout v7, which otherwise refuses to check
+          # out fork code under `pull_request_target`. See the note on this job:
+          # the opt-in is only safe while this job stays free of secrets.
+          allow-unsafe-pr-checkout: true
       - name: "Installing Nix"
         uses: "cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342" # v31.11.0
       - name: "Build"


### PR DESCRIPTION
## Problem

Every pull request from a fork has failed CI since 2026-06-22. `Check nixos.org PR` errors after about four seconds, before any code is fetched:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow.

`build` and `publish` then skip, so fork PRs get no build and no Netlify preview. The cause is the `actions/checkout` v7.0.0 bump in #2052: v7 refuses the `pull_request_target` plus fork-head checkout pattern without an explicit opt-in.

The split is clean across every PR since then. Fork PRs #2056, #2065, #2066, #2076, #2081 and #2084 all failed this way and were merged anyway, so six community contributions have landed with no build and no preview; #2059 and #2085 are still open and red. Same-repo PRs such as #2068, #2074 and #2080 are unaffected, because the guard skips PRs whose head repo is the base repo. That is also why dependabot never surfaced the regression: its branches live in this repository.

## Fix

Set `allow-unsafe-pr-checkout: true` on the two steps that check out PR code, restoring the fork previews added in #1709.

The guard exists because `pull_request_target` can expose the base repository's token, secrets, and cache scope to untrusted code. None of that applies here: `check` and `build` check out PR code but reference no secrets and hold only `contents: read`, while `publish` holds the Netlify credentials but has no checkout step and only downloads the build artifact. This workflow also sets neither `production-branch` nor `production-deploy`, so fork content can only ever reach a Netlify draft deploy. The workflow uses no Actions cache, and the Cachix signing key is confined to `deploy-prod.yml`. This is the separation already recorded in `.github/zizmor.yml` as the reason `dangerous-triggers` is ignored for this workflow.

I also commented both jobs, since the opt-in is only safe while they stay free of secrets.

## Verification

- In checkout at the pinned SHA (v7.0.1), `assertSafePrCheckout` in `src/unsafe-pr-checkout-helper.ts` returns as soon as the input is set, before evaluating any other condition, so it removes this error outright. The input is declared in that commit's `action.yml`.
- The guard is the only blocker: fork PRs fail inside the checkout step, before any other step runs.
- Everything past checkout already works with these exact pins: #2080 ran on `pull_request_target` at 2026-07-21T21:08Z, about ten hours after #2079 pinned v7.0.1, and `check`, `build`, `publish` and the preview all passed.
- `actionlint` is clean, and `zizmor` reports no new findings under either the default or the `--persona auditor` used by the pre-commit hook.

Not verified: no fork PR has run with the flag. Since the guard returns early when the head repo id equals the base repo id, a PR within my own fork cannot reproduce the failure; that needs a fork owned by a second account.

**This PR's own CI will still fail, which is expected.** `pull_request_target` runs the workflow definition from the base branch, so this PR runs main's unmodified copy. It cannot go green until merged.

## Alternative considered

The structural fix is to drop `pull_request_target`: `check` and `build` on `pull_request`, `publish` on `workflow_run`, which is what the zizmor comment anticipates. Not done here because `nwtgck/actions-netlify` resolves the PR from `context.issue.number` and `context.payload.pull_request`, both absent under `workflow_run` for fork PRs, so it would silently stop commenting and attach the commit status to the wrong SHA. That replaces the preview mechanism rather than reconfiguring it. Happy to take it on separately.
